### PR TITLE
IBP-7142 kmp export brapi images

### DIFF
--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/brapi/BrAPIService.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/brapi/BrAPIService.kt
@@ -1,6 +1,7 @@
 package com.fieldbook.shared.brapi
 
 import com.fieldbook.shared.brapi.model.v2.core.BrapiStudyDetails
+import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiImageExport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationExport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationImport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationUnitDetails
@@ -36,6 +37,14 @@ interface BrAPIService {
     suspend fun updateObservations(
         observations: List<BrapiObservationExport>,
     ): BrapiResult<List<BrapiObservationExport>>
+
+    suspend fun createImages(
+        images: List<BrapiImageExport>,
+    ): BrapiResult<List<BrapiImageExport>>
+
+    suspend fun updateImages(
+        images: List<BrapiImageExport>,
+    ): BrapiResult<List<BrapiImageExport>>
 }
 
 sealed interface BrapiResult<out T> {

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/brapi/BrAPIServiceV1.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/brapi/BrAPIServiceV1.kt
@@ -1,6 +1,7 @@
 package com.fieldbook.shared.brapi
 
 import com.fieldbook.shared.brapi.model.v2.core.BrapiStudyDetails
+import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiImageExport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationExport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationImport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationUnitDetails
@@ -184,6 +185,26 @@ class BrAPIServiceV1(
         observations: List<BrapiObservationExport>,
     ): BrapiResult<List<BrapiObservationExport>> {
         return exportObservations(observations)
+    }
+
+    override suspend fun createImages(
+        images: List<BrapiImageExport>,
+    ): BrapiResult<List<BrapiImageExport>> {
+        return if (images.isEmpty()) {
+            BrapiResult.Success(emptyList())
+        } else {
+            BrapiResult.Failure(message = "BrAPI image upload requires BrAPI v2.")
+        }
+    }
+
+    override suspend fun updateImages(
+        images: List<BrapiImageExport>,
+    ): BrapiResult<List<BrapiImageExport>> {
+        return if (images.isEmpty()) {
+            BrapiResult.Success(emptyList())
+        } else {
+            BrapiResult.Failure(message = "BrAPI image upload requires BrAPI v2.")
+        }
     }
 
     private suspend fun exportObservations(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/brapi/BrAPIServiceV2.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/brapi/BrAPIServiceV2.kt
@@ -1,24 +1,39 @@
 package com.fieldbook.shared.brapi
 
 import com.fieldbook.shared.brapi.model.v2.core.BrapiStudyDetails
+import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiImageExport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationExport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationImport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationUnitDetails
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiTraitDetails
-import com.fieldbook.shared.utilities.CategoryJsonUtil
 import com.fieldbook.shared.generated.brapi.v2.core.api.StudiesApi
 import com.fieldbook.shared.generated.brapi.v2.germplasm.api.GermplasmApi
 import com.fieldbook.shared.generated.brapi.v2.germplasm.model.Germplasm
+import com.fieldbook.shared.generated.brapi.v2.phenotyping.api.ImagesApi
 import com.fieldbook.shared.generated.brapi.v2.phenotyping.api.ObservationUnitsApi
 import com.fieldbook.shared.generated.brapi.v2.phenotyping.api.ObservationVariablesApi
 import com.fieldbook.shared.generated.brapi.v2.phenotyping.api.ObservationsApi
+import com.fieldbook.shared.generated.brapi.v2.phenotyping.infrastructure.ApiClient
 import com.fieldbook.shared.generated.brapi.v2.phenotyping.model.ExternalReferencesInner
+import com.fieldbook.shared.generated.brapi.v2.phenotyping.model.Image
+import com.fieldbook.shared.generated.brapi.v2.phenotyping.model.ImageNewRequest
+import com.fieldbook.shared.generated.brapi.v2.phenotyping.model.ImageSingleResponse
 import com.fieldbook.shared.generated.brapi.v2.phenotyping.model.Observation
 import com.fieldbook.shared.generated.brapi.v2.phenotyping.model.ObservationNewRequest
 import com.fieldbook.shared.generated.brapi.v2.phenotyping.model.ObservationUnit
 import com.fieldbook.shared.generated.brapi.v2.phenotyping.model.ObservationVariable
 import com.fieldbook.shared.generated.brapi.v2.phenotyping.model.ObservationVariableScale
 import com.fieldbook.shared.utilities.BrAPIScaleValidValuesCategories
+import com.fieldbook.shared.utilities.CategoryJsonUtil
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import io.ktor.http.encodeURLQueryComponent
 
 class BrAPIServiceV2(
     baseUrl: String,
@@ -33,8 +48,12 @@ class BrAPIServiceV2(
     private val observationsApi: ObservationsApi = ObservationsApi(
         baseUrl = normalizeV2BaseUrl(baseUrl)
     ),
+    private val imagesApi: ImagesApi = ImagesApi(baseUrl = normalizeV2BaseUrl(baseUrl)),
     private val germplasmApi: GermplasmApi = GermplasmApi(baseUrl = normalizeV2BaseUrl(baseUrl)),
+    private val httpClient: HttpClient = HttpClient(),
 ) : BrAPIService {
+    private val v2BaseUrl = normalizeV2BaseUrl(baseUrl)
+
     private data class BrapiGermplasmDetails(
         val accessionNumber: String? = null,
         val pedigree: String? = null,
@@ -47,6 +66,7 @@ class BrAPIServiceV2(
             observationVariablesApi.setBearerToken(bearerToken)
             observationUnitsApi.setBearerToken(bearerToken)
             observationsApi.setBearerToken(bearerToken)
+            imagesApi.setBearerToken(bearerToken)
             germplasmApi.setBearerToken(bearerToken)
         }
     }
@@ -255,6 +275,84 @@ class BrAPIServiceV2(
         }
     }
 
+    override suspend fun createImages(
+        images: List<BrapiImageExport>,
+    ): BrapiResult<List<BrapiImageExport>> {
+        if (images.isEmpty()) return BrapiResult.Success(emptyList())
+        return exportImages(images, updateMetadata = false)
+    }
+
+    override suspend fun updateImages(
+        images: List<BrapiImageExport>,
+    ): BrapiResult<List<BrapiImageExport>> {
+        if (images.isEmpty()) return BrapiResult.Success(emptyList())
+        return exportImages(images, updateMetadata = true)
+    }
+
+    private suspend fun exportImages(
+        images: List<BrapiImageExport>,
+        updateMetadata: Boolean,
+    ): BrapiResult<List<BrapiImageExport>> {
+        return try {
+            val uploaded = mutableListOf<BrapiImageExport>()
+
+            images.forEach { image ->
+                val metadata = if (updateMetadata) {
+                    val imageDbId = image.imageDbId?.takeIf { it.isNotBlank() }
+                        ?: return BrapiResult.Failure(message = "Image ${image.fileName} is missing imageDbId.")
+                    val response = imagesApi.imagesImageDbIdPut(
+                        imageDbId = imageDbId,
+                        imageNewRequest = image.toNewRequest(),
+                    )
+                    if (!response.success) return BrapiResult.Failure(statusCode = response.status)
+                    response.body().result
+                } else {
+                    val response = imagesApi.imagesPost(
+                        imageNewRequest = listOf(image.toNewRequest()),
+                    )
+                    if (!response.success) return BrapiResult.Failure(statusCode = response.status)
+                    response.body().result.data.firstOrNull()
+                        ?: return BrapiResult.Failure(message = "BrAPI image metadata response was empty.")
+                }
+
+                val imageDbId = metadata.imageDbId
+                val uploadedMetadata = uploadImageContent(
+                    imageDbId = imageDbId,
+                    mimeType = image.mimeType,
+                    content = image.content,
+                ) ?: metadata
+                uploaded += uploadedMetadata.toExport(original = image)
+            }
+
+            BrapiResult.Success(uploaded)
+        } catch (error: Exception) {
+            BrapiResult.Failure(message = error.message)
+        }
+    }
+
+    private suspend fun uploadImageContent(
+        imageDbId: String,
+        mimeType: String,
+        content: ByteArray,
+    ): Image? {
+        val response = httpClient.put("$v2BaseUrl/images/${imageDbId.encodeURLQueryComponent()}/imagecontent") {
+            if (!bearerToken.isNullOrBlank()) {
+                header(HttpHeaders.Authorization, "Bearer $bearerToken")
+            }
+            contentType(ContentType.parse(mimeType))
+            setBody(content)
+        }
+
+        if (response.status.value !in 200..299) {
+            error("BrAPI image content upload failed: ${response.status.value}")
+        }
+
+        val body = response.bodyAsText().takeIf { it.isNotBlank() } ?: return null
+        return runCatching {
+            ApiClient.JSON_DEFAULT.decodeFromString(ImageSingleResponse.serializer(), body).result
+        }.getOrNull()
+    }
+
     private suspend fun fetchStudyGermplasm(
         studyDbId: String,
         pageSize: Int,
@@ -450,6 +548,28 @@ class BrAPIServiceV2(
                 observationVariableName = observationVariableName,
                 studyDbId = studyDbId,
                 value = value,
+            )
+        }
+
+        private fun BrapiImageExport.toNewRequest(): ImageNewRequest {
+            return ImageNewRequest(
+                imageFileName = fileName,
+                imageFileSize = fileSize ?: content.size,
+                imageName = imageName,
+                imageTimeStamp = observationTimeStamp,
+                mimeType = mimeType,
+                observationUnitDbId = observationUnitDbId,
+            )
+        }
+
+        private fun Image.toExport(original: BrapiImageExport): BrapiImageExport {
+            return original.copy(
+                imageDbId = imageDbId,
+                fileName = imageFileName?.takeIf { it.isNotBlank() } ?: original.fileName,
+                imageName = imageName?.takeIf { it.isNotBlank() } ?: original.imageName,
+                mimeType = mimeType?.takeIf { it.isNotBlank() } ?: original.mimeType,
+                fileSize = imageFileSize ?: original.fileSize,
+                observationTimeStamp = imageTimeStamp ?: original.observationTimeStamp,
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/brapi/model/v2/phenotyping/BrapiImageExport.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/brapi/model/v2/phenotyping/BrapiImageExport.kt
@@ -1,0 +1,66 @@
+package com.fieldbook.shared.brapi.model.v2.phenotyping
+
+data class BrapiImageExport(
+    val fieldBookDbId: String,
+    val imageDbId: String? = null,
+    val observationUnitDbId: String,
+    val fileName: String,
+    val imageName: String = fileName,
+    val mimeType: String = DEFAULT_MIME_TYPE,
+    val fileSize: Int? = null,
+    val observationTimeStamp: String? = null,
+    val lastSyncedTime: String? = null,
+    val content: ByteArray,
+) {
+    enum class Status {
+        NEW,
+        SYNCED,
+        EDITED,
+        INCOMPLETE,
+        INVALID
+    }
+
+    val status: Status
+        get() = when {
+            content.isEmpty() -> Status.INVALID
+            imageDbId.isNullOrBlank() -> Status.NEW
+            lastSyncedTime.isNullOrBlank() -> Status.INCOMPLETE
+            observationTimeStamp.isNullOrBlank() || observationTimeStamp <= lastSyncedTime -> Status.SYNCED
+            observationTimeStamp > lastSyncedTime -> Status.EDITED
+            else -> Status.INVALID
+        }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BrapiImageExport) return false
+
+        return fieldBookDbId == other.fieldBookDbId &&
+            imageDbId == other.imageDbId &&
+            observationUnitDbId == other.observationUnitDbId &&
+            fileName == other.fileName &&
+            imageName == other.imageName &&
+            mimeType == other.mimeType &&
+            fileSize == other.fileSize &&
+            observationTimeStamp == other.observationTimeStamp &&
+            lastSyncedTime == other.lastSyncedTime &&
+            content.contentEquals(other.content)
+    }
+
+    override fun hashCode(): Int {
+        var result = fieldBookDbId.hashCode()
+        result = 31 * result + (imageDbId?.hashCode() ?: 0)
+        result = 31 * result + observationUnitDbId.hashCode()
+        result = 31 * result + fileName.hashCode()
+        result = 31 * result + imageName.hashCode()
+        result = 31 * result + mimeType.hashCode()
+        result = 31 * result + (fileSize ?: 0)
+        result = 31 * result + (observationTimeStamp?.hashCode() ?: 0)
+        result = 31 * result + (lastSyncedTime?.hashCode() ?: 0)
+        result = 31 * result + content.contentHashCode()
+        return result
+    }
+
+    companion object {
+        const val DEFAULT_MIME_TYPE = "image/jpeg"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/database/repository/ObservationRepository.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/database/repository/ObservationRepository.kt
@@ -16,6 +16,32 @@ data class ExistingBrapiObservation(
     val timestamp: String?,
 )
 
+data class BrapiExportObservationRow(
+    val id: Long,
+    val value: String?,
+    val observationTimeStamp: String?,
+    val observationUnitDbId: String?,
+    val observationDbId: String?,
+    val lastSyncedTime: String?,
+    val collector: String?,
+    val studyDbId: String?,
+    val externalTraitDbId: String?,
+    val observationVariableName: String?,
+    val observationVariableFieldBookFormat: String?,
+)
+
+data class BrapiExportImageRow(
+    val id: Long,
+    val value: String?,
+    val observationTimeStamp: String?,
+    val observationUnitDbId: String?,
+    val imageDbId: String?,
+    val lastSyncedTime: String?,
+    val observationVariableName: String?,
+    val studyAlias: String?,
+    val studyName: String?,
+)
+
 class ObservationRepository() {
     private val db: FieldbookDatabase
         get() = createDatabase()
@@ -189,6 +215,70 @@ class ObservationRepository() {
                     timestamp = row.observation_time_stamp,
                 )
             }
+    }
+
+    fun getBrapiExportObservations(studyId: Long, hostUrl: String): List<BrapiExportObservationRow> {
+        return db.observationsQueries.getBrapiExportObservations(
+            study_id = studyId,
+            trait_data_source = hostUrl,
+        ).executeAsList().map { row ->
+            BrapiExportObservationRow(
+                id = row.id,
+                value = row.value_,
+                observationTimeStamp = row.observation_time_stamp,
+                observationUnitDbId = row.observation_unit_id,
+                observationDbId = row.observation_db_id,
+                lastSyncedTime = row.last_synced_time,
+                collector = row.collector,
+                studyDbId = row.study_db_id,
+                externalTraitDbId = row.external_db_id,
+                observationVariableName = row.observation_variable_name,
+                observationVariableFieldBookFormat = row.observation_variable_field_book_format,
+            )
+        }
+    }
+
+    fun getBrapiExportImages(studyId: Long, hostUrl: String): List<BrapiExportImageRow> {
+        return db.observationsQueries.getBrapiExportImages(
+            study_id = studyId,
+            trait_data_source = hostUrl,
+        ).executeAsList().map { row ->
+            BrapiExportImageRow(
+                id = row.id,
+                value = row.value_,
+                observationTimeStamp = row.observation_time_stamp,
+                observationUnitDbId = row.observation_unit_id,
+                imageDbId = row.observation_db_id,
+                lastSyncedTime = row.last_synced_time,
+                observationVariableName = row.observation_variable_name,
+                studyAlias = row.study_alias,
+                studyName = row.study_name,
+            )
+        }
+    }
+
+    fun countLocalBrapiExportObservations(studyId: Long): Int {
+        return db.observationsQueries.countLocalBrapiExportObservations(studyId)
+            .executeAsOne()
+            .toInt()
+    }
+
+    fun countWrongSourceBrapiExportObservations(hostUrl: String): Int {
+        return db.observationsQueries.countWrongSourceBrapiExportObservations(hostUrl)
+            .executeAsOne()
+            .toInt()
+    }
+
+    fun updateBrapiExportSyncState(
+        observationId: Long,
+        remoteDbId: String,
+        lastSyncedTime: String,
+    ) {
+        db.observationsQueries.updateBrapiExportSyncState(
+            observation_db_id = remoteDbId,
+            last_synced_time = lastSyncedTime,
+            internal_id_observation = observationId,
+        )
     }
 
     fun getObservation(studyId: Long, plotId: String, traitId: Long): ObservationObject? {

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/ConfigScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/ConfigScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -65,6 +64,7 @@ import com.fieldbook.shared.generated.resources.trait_date_save
 import com.fieldbook.shared.preferences.GeneralKeys
 import com.fieldbook.shared.screens.onboarding.OnboardingScreen
 import com.fieldbook.shared.theme.AlertDialog
+import com.fieldbook.shared.theme.TextButton
 import com.russhwolf.settings.Settings
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/datagrid/DataGridScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/datagrid/DataGridScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -42,6 +41,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.fieldbook.shared.theme.AlertDialog
+import com.fieldbook.shared.theme.TextButton
 import eu.wewox.lazytable.LazyTable
 import eu.wewox.lazytable.LazyTableItem
 import eu.wewox.lazytable.lazyTableDimensions

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/BrapiExportSupport.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/BrapiExportSupport.kt
@@ -1,13 +1,12 @@
 package com.fieldbook.shared.screens.export
 
-import app.cash.sqldelight.db.QueryResult
-import app.cash.sqldelight.db.SqlDriver
-import com.fieldbook.shared.AppContext
 import com.fieldbook.shared.brapi.BrAPIService
 import com.fieldbook.shared.brapi.BrapiResult
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiImageExport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationExport
 import com.fieldbook.shared.database.models.FieldObject
+import com.fieldbook.shared.database.repository.BrapiExportObservationRow
+import com.fieldbook.shared.database.repository.ObservationRepository
 import com.fieldbook.shared.database.repository.StudyRepository
 import com.fieldbook.shared.objects.ImportFormat
 import com.fieldbook.shared.utilities.CategoryJsonUtil
@@ -59,10 +58,8 @@ data class BrapiExportResult(
 
 class BrapiExportSupport(
     private val studyRepository: StudyRepository = StudyRepository(),
+    private val observationRepository: ObservationRepository = ObservationRepository(),
 ) {
-    private val driver: SqlDriver
-        get() = AppContext.driverFactory().getDriver()
-
     fun preview(fieldIds: List<Int>, hostUrl: String): BrapiExportPreview {
         val fields = fieldIds.map { studyRepository.getById(it) }
         val invalidFields = fields.filterNot { it.isBrapiFieldFrom(hostUrl) }
@@ -187,117 +184,40 @@ class BrapiExportSupport(
     }
 
     private fun getBrapiObservations(fieldId: Int, hostUrl: String): List<BrapiObservationExport> {
-        val sql = """
-            SELECT
-                obs.internal_id_observation AS id,
-                obs.value AS value,
-                obs.observation_time_stamp,
-                obs.observation_unit_id,
-                obs.observation_variable_db_id,
-                obs.observation_db_id,
-                obs.last_synced_time,
-                obs.collector,
-                obs.rep,
-                study.study_db_id,
-                vars.external_db_id,
-                vars.observation_variable_name,
-                vars.observation_variable_field_book_format
-            FROM observations AS obs
-            JOIN observation_variables AS vars ON obs.observation_variable_db_id = vars.internal_id_observation_variable
-            JOIN studies AS study ON obs.study_id = study.internal_id_study
-            WHERE obs.study_id = ?
-              AND study.study_source IS NOT NULL
-              AND obs.value <> ''
-              AND vars.trait_data_source = ?
-              AND vars.trait_data_source IS NOT NULL
-              AND vars.observation_variable_field_book_format <> 'photo'
-        """.trimIndent()
-
-        return executeQueryRows(sql, 2, 13) {
-            bindLong(0, fieldId.toLong())
-            bindString(1, hostUrl)
-        }.mapNotNull { values ->
-            val row = listOf(
-                "id",
-                "value",
-                "observation_time_stamp",
-                "observation_unit_id",
-                "observation_variable_db_id",
-                "observation_db_id",
-                "last_synced_time",
-                "collector",
-                "rep",
-                "study_db_id",
-                "external_db_id",
-                "observation_variable_name",
-                "observation_variable_field_book_format",
-            ).zip(values).toMap()
-
-            val value = CategoryJsonUtil.processValue(row)
-            val variableDbId = row["external_db_id"]?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-            val unitDbId = row["observation_unit_id"]?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-            val studyDbId = row["study_db_id"]?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        return observationRepository.getBrapiExportObservations(
+            studyId = fieldId.toLong(),
+            hostUrl = hostUrl,
+        ).mapNotNull { row ->
+            val value = CategoryJsonUtil.processValue(row.toCategoryValueMap())
+            val variableDbId = row.externalTraitDbId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val unitDbId = row.observationUnitDbId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val studyDbId = row.studyDbId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
 
             BrapiObservationExport(
-                fieldBookDbId = row["id"].orEmpty(),
-                observationDbId = row["observation_db_id"],
+                fieldBookDbId = row.id.toString(),
+                observationDbId = row.observationDbId,
                 observationUnitDbId = unitDbId,
                 observationVariableDbId = variableDbId,
-                observationVariableName = row["observation_variable_name"],
+                observationVariableName = row.observationVariableName,
                 studyDbId = studyDbId,
                 value = value.orEmpty(),
-                observationTimeStamp = row["observation_time_stamp"],
-                lastSyncedTime = row["last_synced_time"],
-                collector = row["collector"],
+                observationTimeStamp = row.observationTimeStamp,
+                lastSyncedTime = row.lastSyncedTime,
+                collector = row.collector,
             )
         }
     }
 
     private fun getBrapiImages(fieldId: Int, hostUrl: String): List<BrapiImageExport> {
-        val sql = """
-            SELECT
-                obs.internal_id_observation AS id,
-                obs.value AS value,
-                obs.observation_time_stamp,
-                obs.observation_unit_id,
-                obs.observation_db_id,
-                obs.last_synced_time,
-                vars.observation_variable_name,
-                study.study_alias,
-                study.study_name
-            FROM observations AS obs
-            JOIN observation_variables AS vars ON obs.observation_variable_db_id = vars.internal_id_observation_variable
-            JOIN studies AS study ON obs.study_id = study.internal_id_study
-            WHERE obs.study_id = ?
-              AND study.study_source IS NOT NULL
-              AND obs.value <> ''
-              AND vars.trait_data_source = ?
-              AND vars.trait_data_source IS NOT NULL
-              AND vars.observation_variable_field_book_format = 'photo'
-        """.trimIndent()
+        return observationRepository.getBrapiExportImages(
+            studyId = fieldId.toLong(),
+            hostUrl = hostUrl,
+        ).flatMap { row ->
+            val unitDbId = row.observationUnitDbId?.takeIf { it.isNotBlank() } ?: return@flatMap emptyList()
+            val traitName = row.observationVariableName?.takeIf { it.isNotBlank() }
+            val fieldName = row.studyAlias?.takeIf { it.isNotBlank() } ?: row.studyName
 
-        return executeQueryRows(sql, 2, 9) {
-            bindLong(0, fieldId.toLong())
-            bindString(1, hostUrl)
-        }.flatMap { values ->
-            val row = listOf(
-                "id",
-                "value",
-                "observation_time_stamp",
-                "observation_unit_id",
-                "observation_db_id",
-                "last_synced_time",
-                "observation_variable_name",
-                "study_alias",
-                "study_name",
-            ).zip(values).toMap()
-
-            val fieldBookDbId = row["id"].orEmpty()
-            val unitDbId = row["observation_unit_id"]?.takeIf { it.isNotBlank() } ?: return@flatMap emptyList()
-            val traitName = row["observation_variable_name"]?.takeIf { it.isNotBlank() }
-            val fieldName = row["study_alias"]?.takeIf { it.isNotBlank() } ?: row["study_name"]
-
-            decodePhotoRefs(row["value"].orEmpty()).mapNotNull { photoRef ->
+            decodePhotoRefs(row.value.orEmpty()).map { photoRef ->
                 val file = findStoredPhotoFile(
                     photoRef = photoRef,
                     fieldName = fieldName,
@@ -308,15 +228,15 @@ class BrapiExportSupport(
                 val mimeType = fileName.toImageMimeType()
 
                 BrapiImageExport(
-                    fieldBookDbId = fieldBookDbId,
-                    imageDbId = row["observation_db_id"],
+                    fieldBookDbId = row.id.toString(),
+                    imageDbId = row.imageDbId,
                     observationUnitDbId = unitDbId,
                     fileName = fileName,
                     imageName = fileName,
                     mimeType = mimeType,
                     fileSize = content.size,
-                    observationTimeStamp = row["observation_time_stamp"],
-                    lastSyncedTime = row["last_synced_time"],
+                    observationTimeStamp = row.observationTimeStamp,
+                    lastSyncedTime = row.lastSyncedTime,
                     content = content,
                 )
             }
@@ -324,53 +244,11 @@ class BrapiExportSupport(
     }
 
     private fun countLocalObservations(fieldId: Int): Int {
-        return countRows(
-            """
-                SELECT COUNT(*)
-                FROM observations AS obs
-                JOIN observation_variables AS vars ON obs.observation_variable_db_id = vars.internal_id_observation_variable
-                WHERE obs.study_id = ?
-                  AND vars.observation_variable_field_book_format <> 'photo'
-                  AND (vars.trait_data_source = 'local' OR vars.trait_data_source IS NULL)
-            """.trimIndent(),
-            fieldId,
-        )
+        return observationRepository.countLocalBrapiExportObservations(fieldId.toLong())
     }
 
     private fun countWrongSourceObservations(hostUrl: String): Int {
-        val result = driver.executeQuery(
-            identifier = null,
-            sql = """
-                SELECT COUNT(*)
-                FROM observations AS obs
-                JOIN observation_variables AS vars ON obs.observation_variable_db_id = vars.internal_id_observation_variable
-                WHERE vars.observation_variable_field_book_format <> 'photo'
-                  AND vars.trait_data_source <> ?
-                  AND vars.trait_data_source <> 'local'
-                  AND vars.trait_data_source IS NOT NULL
-            """.trimIndent(),
-            mapper = { cursor ->
-                cursor.next().value
-                QueryResult.Value(cursor.getLong(0) ?: 0L)
-            },
-            parameters = 1,
-            binders = { bindString(0, hostUrl) }
-        )
-        return result.value.toInt()
-    }
-
-    private fun countRows(sql: String, fieldId: Int): Int {
-        val result = driver.executeQuery(
-            identifier = null,
-            sql = sql,
-            mapper = { cursor ->
-                cursor.next().value
-                QueryResult.Value(cursor.getLong(0) ?: 0L)
-            },
-            parameters = 1,
-            binders = { bindLong(0, fieldId.toLong()) }
-        )
-        return result.value.toInt()
+        return observationRepository.countWrongSourceBrapiExportObservations(hostUrl)
     }
 
     private fun updateLocalSyncState(
@@ -394,15 +272,11 @@ class BrapiExportSupport(
                 ?: original.observationDbId
                 ?: return@forEach
 
-            driver.execute(
-                identifier = null,
-                sql = "UPDATE observations SET observation_db_id = ?, last_synced_time = ? WHERE internal_id_observation = ?",
-                parameters = 3,
-            ) {
-                bindString(0, observationDbId)
-                bindString(1, now)
-                bindLong(2, original.fieldBookDbId.toLong())
-            }
+            observationRepository.updateBrapiExportSyncState(
+                observationId = original.fieldBookDbId.toLong(),
+                remoteDbId = observationDbId,
+                lastSyncedTime = now,
+            )
         }
     }
 
@@ -424,15 +298,11 @@ class BrapiExportSupport(
                 ?: original.imageDbId
                 ?: return@forEach
 
-            driver.execute(
-                identifier = null,
-                sql = "UPDATE observations SET observation_db_id = ?, last_synced_time = ? WHERE internal_id_observation = ?",
-                parameters = 3,
-            ) {
-                bindString(0, imageDbId)
-                bindString(1, now)
-                bindLong(2, original.fieldBookDbId.toLong())
-            }
+            observationRepository.updateBrapiExportSyncState(
+                observationId = original.fieldBookDbId.toLong(),
+                remoteDbId = imageDbId,
+                lastSyncedTime = now,
+            )
         }
     }
 
@@ -515,26 +385,20 @@ class BrapiExportSupport(
         }
     }
 
-    private fun executeQueryRows(
-        sql: String,
-        parameterCount: Int,
-        columnCount: Int,
-        binder: app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit = {},
-    ): List<List<String?>> {
-        val result: QueryResult<List<List<String?>>> = driver.executeQuery(
-            identifier = null,
-            sql = sql,
-            mapper = { cursor ->
-                val rows = mutableListOf<List<String?>>()
-                while (cursor.next().value) {
-                    rows += List(columnCount) { index -> cursor.getString(index) }
-                }
-                QueryResult.Value(rows)
-            },
-            parameters = parameterCount,
-            binders = binder
+    private fun BrapiExportObservationRow.toCategoryValueMap(): Map<String, String?> {
+        return mapOf(
+            "id" to id.toString(),
+            "value" to value,
+            "observation_time_stamp" to observationTimeStamp,
+            "observation_unit_id" to observationUnitDbId,
+            "observation_db_id" to observationDbId,
+            "last_synced_time" to lastSyncedTime,
+            "collector" to collector,
+            "study_db_id" to studyDbId,
+            "external_db_id" to externalTraitDbId,
+            "observation_variable_name" to observationVariableName,
+            "observation_variable_field_book_format" to observationVariableFieldBookFormat,
         )
-        return result.value
     }
 
     private companion object {

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/BrapiExportSupport.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/BrapiExportSupport.kt
@@ -5,12 +5,16 @@ import app.cash.sqldelight.db.SqlDriver
 import com.fieldbook.shared.AppContext
 import com.fieldbook.shared.brapi.BrAPIService
 import com.fieldbook.shared.brapi.BrapiResult
+import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiImageExport
 import com.fieldbook.shared.brapi.model.v2.phenotyping.BrapiObservationExport
 import com.fieldbook.shared.database.models.FieldObject
 import com.fieldbook.shared.database.repository.StudyRepository
 import com.fieldbook.shared.objects.ImportFormat
 import com.fieldbook.shared.utilities.CategoryJsonUtil
+import com.fieldbook.shared.utilities.DocumentFile
+import com.fieldbook.shared.utilities.DocumentTreeUtil
 import com.fieldbook.shared.utilities.internalTimeFormatter
+import com.fieldbook.shared.utilities.listFiles
 import kotlinx.datetime.Clock
 import kotlinx.datetime.format
 
@@ -24,6 +28,10 @@ data class BrapiExportPreview(
     val editedObservations: Int = fields.sumOf { it.editedObservations }
     val localObservations: Int = fields.sumOf { it.localObservations }
     val wrongSourceObservations: Int = fields.sumOf { it.wrongSourceObservations }
+    val newImages: Int = fields.sumOf { it.newImages }
+    val syncedImages: Int = fields.sumOf { it.syncedImages }
+    val editedImages: Int = fields.sumOf { it.editedImages }
+    val invalidImages: Int = fields.sumOf { it.invalidImages }
 }
 
 data class BrapiFieldExportPreview(
@@ -34,12 +42,19 @@ data class BrapiFieldExportPreview(
     val editedObservations: Int,
     val localObservations: Int,
     val wrongSourceObservations: Int,
+    val newImages: Int,
+    val syncedImages: Int,
+    val editedImages: Int,
+    val invalidImages: Int,
 )
 
 data class BrapiExportResult(
     val created: Int,
     val updated: Int,
     val skippedSynced: Int,
+    val imagesCreated: Int,
+    val imagesUpdated: Int,
+    val imagesSkippedSynced: Int,
 )
 
 class BrapiExportSupport(
@@ -62,6 +77,7 @@ class BrapiExportSupport(
         val previews = fields.mapNotNull { field ->
             val fieldId = field.exp_id ?: return@mapNotNull null
             val observations = getBrapiObservations(fieldId, hostUrl)
+            val images = getBrapiImages(fieldId, hostUrl)
             BrapiFieldExportPreview(
                 fieldId = fieldId,
                 fieldName = field.exp_alias.ifBlank { field.exp_name },
@@ -70,13 +86,17 @@ class BrapiExportSupport(
                 editedObservations = observations.count { it.status == BrapiObservationExport.Status.EDITED || it.status == BrapiObservationExport.Status.INCOMPLETE },
                 localObservations = countLocalObservations(fieldId),
                 wrongSourceObservations = countWrongSourceObservations(hostUrl),
+                newImages = images.count { it.status == BrapiImageExport.Status.NEW },
+                syncedImages = images.count { it.status == BrapiImageExport.Status.SYNCED },
+                editedImages = images.count { it.status == BrapiImageExport.Status.EDITED || it.status == BrapiImageExport.Status.INCOMPLETE },
+                invalidImages = images.count { it.status == BrapiImageExport.Status.INVALID },
             )
         }
 
         return BrapiExportPreview(
             fields = previews,
             canExport = true,
-            message = if (previews.sumOf { it.newObservations + it.editedObservations } == 0) {
+            message = if (previews.sumOf { it.newObservations + it.editedObservations + it.newImages + it.editedImages } == 0) {
                 "Nothing to sync"
             } else {
                 null
@@ -90,15 +110,24 @@ class BrapiExportSupport(
         service: BrAPIService,
     ): BrapiResult<BrapiExportResult> {
         val observations = fieldIds.flatMap { getBrapiObservations(it, hostUrl) }
+        val images = fieldIds.flatMap { getBrapiImages(it, hostUrl) }
         val newObservations = observations
             .filter { it.status == BrapiObservationExport.Status.NEW }
             .map { it.withBrapiTimestamp() }
         val editedObservations = observations
             .filter { it.status == BrapiObservationExport.Status.EDITED || it.status == BrapiObservationExport.Status.INCOMPLETE }
             .map { it.withBrapiTimestamp() }
+        val newImages = images
+            .filter { it.status == BrapiImageExport.Status.NEW }
+            .map { it.withBrapiTimestamp() }
+        val editedImages = images
+            .filter { it.status == BrapiImageExport.Status.EDITED || it.status == BrapiImageExport.Status.INCOMPLETE }
+            .map { it.withBrapiTimestamp() }
 
         var created = 0
         var updated = 0
+        var imagesCreated = 0
+        var imagesUpdated = 0
 
         if (newObservations.isNotEmpty()) {
             when (val result = service.createObservations(newObservations)) {
@@ -120,11 +149,34 @@ class BrapiExportSupport(
             }
         }
 
+        if (newImages.isNotEmpty()) {
+            when (val result = service.createImages(newImages)) {
+                is BrapiResult.Failure -> return result
+                is BrapiResult.Success -> {
+                    updateLocalImageSyncState(newImages, result.value)
+                    imagesCreated = result.value.size
+                }
+            }
+        }
+
+        if (editedImages.isNotEmpty()) {
+            when (val result = service.updateImages(editedImages)) {
+                is BrapiResult.Failure -> return result
+                is BrapiResult.Success -> {
+                    updateLocalImageSyncState(editedImages, result.value)
+                    imagesUpdated = result.value.size
+                }
+            }
+        }
+
         return BrapiResult.Success(
             BrapiExportResult(
                 created = created,
                 updated = updated,
                 skippedSynced = observations.count { it.status == BrapiObservationExport.Status.SYNCED },
+                imagesCreated = imagesCreated,
+                imagesUpdated = imagesUpdated,
+                imagesSkippedSynced = images.count { it.status == BrapiImageExport.Status.SYNCED },
             )
         )
     }
@@ -198,6 +250,76 @@ class BrapiExportSupport(
                 lastSyncedTime = row["last_synced_time"],
                 collector = row["collector"],
             )
+        }
+    }
+
+    private fun getBrapiImages(fieldId: Int, hostUrl: String): List<BrapiImageExport> {
+        val sql = """
+            SELECT
+                obs.internal_id_observation AS id,
+                obs.value AS value,
+                obs.observation_time_stamp,
+                obs.observation_unit_id,
+                obs.observation_db_id,
+                obs.last_synced_time,
+                vars.observation_variable_name,
+                study.study_alias,
+                study.study_name
+            FROM observations AS obs
+            JOIN observation_variables AS vars ON obs.observation_variable_db_id = vars.internal_id_observation_variable
+            JOIN studies AS study ON obs.study_id = study.internal_id_study
+            WHERE obs.study_id = ?
+              AND study.study_source IS NOT NULL
+              AND obs.value <> ''
+              AND vars.trait_data_source = ?
+              AND vars.trait_data_source IS NOT NULL
+              AND vars.observation_variable_field_book_format = 'photo'
+        """.trimIndent()
+
+        return executeQueryRows(sql, 2, 9) {
+            bindLong(0, fieldId.toLong())
+            bindString(1, hostUrl)
+        }.flatMap { values ->
+            val row = listOf(
+                "id",
+                "value",
+                "observation_time_stamp",
+                "observation_unit_id",
+                "observation_db_id",
+                "last_synced_time",
+                "observation_variable_name",
+                "study_alias",
+                "study_name",
+            ).zip(values).toMap()
+
+            val fieldBookDbId = row["id"].orEmpty()
+            val unitDbId = row["observation_unit_id"]?.takeIf { it.isNotBlank() } ?: return@flatMap emptyList()
+            val traitName = row["observation_variable_name"]?.takeIf { it.isNotBlank() }
+            val fieldName = row["study_alias"]?.takeIf { it.isNotBlank() } ?: row["study_name"]
+
+            decodePhotoRefs(row["value"].orEmpty()).mapNotNull { photoRef ->
+                val file = findStoredPhotoFile(
+                    photoRef = photoRef,
+                    fieldName = fieldName,
+                    traitName = traitName,
+                )
+                val content = file?.let { runCatching { it.readBytes() }.getOrDefault(ByteArray(0)) } ?: ByteArray(0)
+                val fileName = file?.name()?.takeIf { it.isNotBlank() } ?: extractPhotoFileName(photoRef)
+                val mimeType = fileName.toImageMimeType()
+
+                BrapiImageExport(
+                    fieldBookDbId = fieldBookDbId,
+                    imageDbId = row["observation_db_id"],
+                    observationUnitDbId = unitDbId,
+                    fileName = fileName,
+                    imageName = fileName,
+                    mimeType = mimeType,
+                    fileSize = content.size,
+                    observationTimeStamp = row["observation_time_stamp"],
+                    lastSyncedTime = row["last_synced_time"],
+                    content = content,
+                )
+            }
         }
     }
 
@@ -284,8 +406,113 @@ class BrapiExportSupport(
         }
     }
 
+    private fun updateLocalImageSyncState(
+        inputImages: List<BrapiImageExport>,
+        responseImages: List<BrapiImageExport>,
+    ) {
+        val now = Clock.System.now().format(internalTimeFormatter)
+        val byFieldBookId = inputImages.associateBy { it.fieldBookDbId }
+        val byImageDbId = inputImages
+            .mapNotNull { image -> image.imageDbId?.let { it to image } }
+            .toMap()
+
+        responseImages.forEach { response ->
+            val original = byFieldBookId[response.fieldBookDbId]
+                ?: response.imageDbId?.let(byImageDbId::get)
+                ?: return@forEach
+            val imageDbId = response.imageDbId?.takeIf { it.isNotBlank() }
+                ?: original.imageDbId
+                ?: return@forEach
+
+            driver.execute(
+                identifier = null,
+                sql = "UPDATE observations SET observation_db_id = ?, last_synced_time = ? WHERE internal_id_observation = ?",
+                parameters = 3,
+            ) {
+                bindString(0, imageDbId)
+                bindString(1, now)
+                bindLong(2, original.fieldBookDbId.toLong())
+            }
+        }
+    }
+
     private fun BrapiObservationExport.withBrapiTimestamp(): BrapiObservationExport {
         return copy(observationTimeStamp = observationTimeStamp?.replaceFirst(' ', 'T'))
+    }
+
+    private fun BrapiImageExport.withBrapiTimestamp(): BrapiImageExport {
+        return copy(observationTimeStamp = observationTimeStamp?.replaceFirst(' ', 'T'))
+    }
+
+    private fun decodePhotoRefs(value: String): List<String> {
+        return value
+            .split(PHOTO_VALUE_SEPARATOR)
+            .map(::normalizeStoredPhotoRef)
+            .filter { it.isNotBlank() }
+    }
+
+    private fun normalizeStoredPhotoRef(raw: String): String {
+        val trimmed = raw.trim()
+        if (trimmed.isBlank()) return ""
+        return when {
+            trimmed.startsWith("http://") || trimmed.startsWith("https://") -> trimmed
+            trimmed.startsWith("content://") -> trimmed
+            trimmed.startsWith("file://") -> trimmed
+            trimmed.startsWith("/") -> "file://$trimmed"
+            else -> trimmed
+        }
+    }
+
+    private fun extractPhotoFileName(photoRef: String): String {
+        return normalizeStoredPhotoRef(photoRef)
+            .substringBefore("?")
+            .substringAfterLast("/")
+            .replace("%20", " ")
+    }
+
+    private fun findStoredPhotoFile(
+        photoRef: String,
+        fieldName: String?,
+        traitName: String?,
+    ): DocumentFile? {
+        val normalizedPhotoRef = normalizeStoredPhotoRef(photoRef)
+        val fileName = extractPhotoFileName(normalizedPhotoRef)
+        if (fileName.isBlank()) return null
+
+        val candidateDirectories = listOfNotNull(
+            DocumentTreeUtil.getFieldMediaDirectory(fieldName, traitName),
+            DocumentTreeUtil.getFieldMediaDirectory(fieldName, PHOTO_DIRECTORY_NAME),
+            DocumentTreeUtil.getPlotDataDirectory(),
+        ).distinctBy { it.uri() }
+
+        candidateDirectories.forEach { directory ->
+            directory.findFile(fileName)
+                ?.takeIf { it.exists() }
+                ?.let { return it }
+
+            listFiles(directory)
+                .firstOrNull { storedFile ->
+                    storedFile.exists() && (
+                        storedFile.uri() == normalizedPhotoRef ||
+                            storedFile.name() == fileName
+                        )
+                    }
+                ?.let { return it }
+        }
+
+        return null
+    }
+
+    private fun String.toImageMimeType(): String {
+        return when (substringAfterLast('.', "").lowercase()) {
+            "jpg",
+            "jpeg" -> "image/jpeg"
+            "png" -> "image/png"
+            "gif" -> "image/gif"
+            "webp" -> "image/webp"
+            "svg" -> "image/svg+xml"
+            else -> BrapiImageExport.DEFAULT_MIME_TYPE
+        }
     }
 
     private fun executeQueryRows(
@@ -308,5 +535,10 @@ class BrapiExportSupport(
             binders = binder
         )
         return result.value
+    }
+
+    private companion object {
+        const val PHOTO_VALUE_SEPARATOR = "\n"
+        const val PHOTO_DIRECTORY_NAME = "photo"
     }
 }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/ExportScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/ExportScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -62,6 +61,7 @@ import com.fieldbook.shared.generated.resources.settings_traits
 import com.fieldbook.shared.generated.resources.traits_create_format
 import com.fieldbook.shared.theme.AlertDialog
 import com.fieldbook.shared.theme.Dialog
+import com.fieldbook.shared.theme.TextButton
 import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
 

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/ExportScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/ExportScreen.kt
@@ -243,6 +243,11 @@ private fun BrapiExportContent(
         BrapiCountRow("Edited", preview?.editedObservations ?: 0)
         BrapiCountRow("Local-only", preview?.localObservations ?: 0)
         BrapiCountRow("Wrong source", preview?.wrongSourceObservations ?: 0)
+        Spacer(modifier = Modifier.height(8.dp))
+        BrapiCountRow("New images", preview?.newImages ?: 0)
+        BrapiCountRow("Synced images", preview?.syncedImages ?: 0)
+        BrapiCountRow("Edited images", preview?.editedImages ?: 0)
+        BrapiCountRow("Missing images", preview?.invalidImages ?: 0)
 
         Spacer(modifier = Modifier.height(20.dp))
 
@@ -257,7 +262,9 @@ private fun BrapiExportContent(
             Spacer(modifier = Modifier.width(8.dp))
             Button(
                 onClick = onSave,
-                enabled = preview?.let { it.canExport && (it.newObservations + it.editedObservations) > 0 } == true,
+                enabled = preview?.let {
+                    it.canExport && (it.newObservations + it.editedObservations + it.newImages + it.editedImages) > 0
+                } == true,
             ) {
                 Text(stringResource(Res.string.settings_export))
             }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/ExportScreenViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/export/ExportScreenViewModel.kt
@@ -141,7 +141,7 @@ class ExportScreenViewModel(
             return
         }
 
-        if (preview.newObservations + preview.editedObservations == 0) {
+        if (preview.newObservations + preview.editedObservations + preview.newImages + preview.editedImages == 0) {
             viewModelScope.launch { _events.emit(ExportEvent.Failed("Nothing to sync")) }
             return
         }
@@ -159,7 +159,7 @@ class ExportScreenViewModel(
                 )
                 is BrapiResult.Success -> _events.emit(
                     ExportEvent.Completed(
-                        "BrAPI export complete: ${result.value.created} new, ${result.value.updated} edited"
+                        "BrAPI export complete: ${result.value.created} new, ${result.value.updated} edited, ${result.value.imagesCreated} images uploaded, ${result.value.imagesUpdated} images updated"
                     )
                 )
             }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldCreatorDialogFragment.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldCreatorDialogFragment.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -47,6 +46,7 @@ import com.fieldbook.shared.objects.ImportFormat
 import com.fieldbook.shared.sqldelight.FieldbookDatabase
 import com.fieldbook.shared.sqldelight.createDatabase
 import com.fieldbook.shared.theme.AlertDialog
+import com.fieldbook.shared.theme.TextButton
 import com.fieldbook.shared.utilities.internalTimeFormatter
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldDetailScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -91,6 +90,7 @@ import com.fieldbook.shared.objects.ImportFormat
 import com.fieldbook.shared.preferences.PreferenceKeys
 import com.fieldbook.shared.theme.AlertDialog
 import com.fieldbook.shared.theme.Dialog
+import com.fieldbook.shared.theme.TextButton
 import com.fieldbook.shared.utilities.checkForIllegalCharacters
 import com.fieldbook.shared.utilities.relativeTimeText
 import com.russhwolf.settings.Settings

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldEditorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldEditorScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -76,6 +75,7 @@ import com.fieldbook.shared.screens.brapi.BrapiFieldImportSupport
 import com.fieldbook.shared.screens.brapi.BrapiStudyPreviewScreen
 import com.fieldbook.shared.screens.brapi.BrapiStudyScreen
 import com.fieldbook.shared.theme.AlertDialog
+import com.fieldbook.shared.theme.TextButton
 import com.fieldbook.shared.utilities.DocumentFile
 import com.fieldbook.shared.utilities.FieldSwitchImpl
 import com.fieldbook.shared.utilities.getDirectory

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/onboarding/OnboardingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/onboarding/OnboardingScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -58,6 +57,7 @@ import com.fieldbook.shared.generated.resources.field_book_mini_percent
 import com.fieldbook.shared.generated.resources.other_ic_field_book
 import com.fieldbook.shared.preferences.GeneralKeys
 import com.fieldbook.shared.theme.AlertDialog
+import com.fieldbook.shared.theme.TextButton
 import com.fieldbook.shared.utilities.configurePickedStorageDirectory
 import com.fieldbook.shared.utilities.detectStorageProviderLabel
 import com.fieldbook.shared.utilities.detectStorageProviderType

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/LanguageScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/LanguageScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -74,6 +73,7 @@ import com.fieldbook.shared.preferences.LanguageSelection
 import com.fieldbook.shared.preferences.PreferenceKeys
 import com.fieldbook.shared.preferences.resolveSystemLanguageSelection
 import com.fieldbook.shared.theme.AlertDialog
+import com.fieldbook.shared.theme.TextButton
 import com.fieldbook.shared.utilities.onLanguageChanged
 import com.russhwolf.settings.Settings
 import org.jetbrains.compose.resources.DrawableResource

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/PreferenceFragments.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/PreferenceFragments.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -24,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.fieldbook.shared.theme.AlertDialog
+import com.fieldbook.shared.theme.TextButton
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/StoragePreferencesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/StoragePreferencesScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -61,6 +60,7 @@ import com.fieldbook.shared.generated.resources.preferences_storage_title
 import com.fieldbook.shared.preferences.GeneralKeys
 import com.fieldbook.shared.screens.export.ExportScreen
 import com.fieldbook.shared.theme.AlertDialog
+import com.fieldbook.shared.theme.TextButton
 import com.fieldbook.shared.utilities.displayStorageDirectoryPath
 import com.fieldbook.shared.utilities.resetLocalDatabaseAndPreferences
 import com.fieldbook.shared.utilities.selectFirstField

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitCreatorDialogFragment.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitCreatorDialogFragment.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -39,6 +38,7 @@ import com.fieldbook.shared.database.models.TraitObject
 import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.dialog_back
 import com.fieldbook.shared.theme.Dialog
+import com.fieldbook.shared.theme.TextButton
 import com.fieldbook.shared.traits.Formats
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitCreatorDialogFragment.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitCreatorDialogFragment.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.fieldbook.shared.database.models.TraitObject
+import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.dialog_back
 import com.fieldbook.shared.theme.Dialog
 import com.fieldbook.shared.traits.Formats
 import org.jetbrains.compose.resources.painterResource
@@ -210,11 +212,11 @@ fun TraitCreatorDialog(
                                 horizontalArrangement = Arrangement.End
                             ) {
                                 Row {
-                                    if (!isEditing) {
+                                    if (!isEditing || !observationsExist) {
                                         TextButton(onClick = {
                                             currentStep = TraitCreatorStep.ChooseFormat
                                         }) {
-                                            Text("Back")
+                                            Text(stringResource(Res.string.dialog_back))
                                         }
                                     }
 

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitEditorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitEditorScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -77,6 +76,7 @@ import com.fieldbook.shared.generated.resources.traits_sort_name
 import com.fieldbook.shared.generated.resources.traits_sort_visibility
 import com.fieldbook.shared.generated.resources.traits_toolbar_delete_all
 import com.fieldbook.shared.theme.AlertDialog
+import com.fieldbook.shared.theme.TextButton
 import com.fieldbook.shared.traits.Formats
 import com.fieldbook.shared.utilities.DocumentFile
 import com.fieldbook.shared.utilities.getDirectory
@@ -303,7 +303,7 @@ fun TraitEditorScreen(
                     title = { Text("Delete trait") },
                     text = { Text("Are you sure you want to delete '${trait.name}'?") },
                     confirmButton = {
-                        androidx.compose.material3.TextButton(onClick = {
+                        TextButton(onClick = {
                             viewModel.deleteTrait(trait.id)
                             traitToDelete = null
                         }) {
@@ -311,7 +311,7 @@ fun TraitEditorScreen(
                         }
                     },
                     dismissButton = {
-                        androidx.compose.material3.TextButton(onClick = {
+                        TextButton(onClick = {
                             traitToDelete = null
                         }) {
                             Text("Cancel")

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/theme/Theme.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/theme/Theme.kt
@@ -1,6 +1,9 @@
 package com.fieldbook.shared.theme
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
@@ -8,6 +11,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ButtonElevation
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.lightColorScheme
@@ -19,6 +23,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.material3.AlertDialog as MaterialAlertDialog
+import androidx.compose.material3.TextButton as MaterialTextButton
 import androidx.compose.ui.window.Dialog as ComposeDialog
 
 private val MainLightColors = lightColorScheme(
@@ -122,7 +127,6 @@ fun FilledIconButton(
 private fun DialogButtonColorTheme(content: @Composable () -> Unit) {
     MaterialTheme(
         colorScheme = MaterialTheme.colorScheme.copy(
-            primary = Color.Black,
             onPrimary = Color.White
         ),
         typography = MaterialTheme.typography,
@@ -143,6 +147,35 @@ fun Dialog(
     ) {
         DialogButtonColorTheme(content = content)
     }
+}
+
+@Composable
+fun TextButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    shape: Shape = ButtonDefaults.textShape,
+    colors: androidx.compose.material3.ButtonColors = ButtonDefaults.textButtonColors(
+        contentColor = Color.Black
+    ),
+    elevation: ButtonElevation? = null,
+    border: BorderStroke? = null,
+    contentPadding: PaddingValues = ButtonDefaults.TextButtonContentPadding,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable RowScope.() -> Unit
+) {
+    MaterialTextButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/sqldelight/com/fieldbook/shared/sqldelight/observations.sq
+++ b/shared/src/commonMain/sqldelight/com/fieldbook/shared/sqldelight/observations.sq
@@ -104,3 +104,78 @@ JOIN observation_variables AS vars
   ON obs.observation_variable_db_id = vars.internal_id_observation_variable
 WHERE obs.study_id = ?
   AND vars.external_db_id IS NOT NULL;
+
+getBrapiExportObservations:
+SELECT
+  obs.internal_id_observation AS id,
+  obs.value AS value,
+  obs.observation_time_stamp,
+  obs.observation_unit_id,
+  obs.observation_variable_db_id,
+  obs.observation_db_id,
+  obs.last_synced_time,
+  obs.collector,
+  obs.rep,
+  study.study_db_id,
+  vars.external_db_id,
+  vars.observation_variable_name,
+  vars.observation_variable_field_book_format
+FROM observations AS obs
+JOIN observation_variables AS vars
+  ON obs.observation_variable_db_id = vars.internal_id_observation_variable
+JOIN studies AS study
+  ON obs.study_id = study.internal_id_study
+WHERE obs.study_id = ?
+  AND study.study_source IS NOT NULL
+  AND obs.value <> ''
+  AND vars.trait_data_source = ?
+  AND vars.trait_data_source IS NOT NULL
+  AND vars.observation_variable_field_book_format <> 'photo';
+
+getBrapiExportImages:
+SELECT
+  obs.internal_id_observation AS id,
+  obs.value AS value,
+  obs.observation_time_stamp,
+  obs.observation_unit_id,
+  obs.observation_db_id,
+  obs.last_synced_time,
+  vars.observation_variable_name,
+  study.study_alias,
+  study.study_name
+FROM observations AS obs
+JOIN observation_variables AS vars
+  ON obs.observation_variable_db_id = vars.internal_id_observation_variable
+JOIN studies AS study
+  ON obs.study_id = study.internal_id_study
+WHERE obs.study_id = ?
+  AND study.study_source IS NOT NULL
+  AND obs.value <> ''
+  AND vars.trait_data_source = ?
+  AND vars.trait_data_source IS NOT NULL
+  AND vars.observation_variable_field_book_format = 'photo';
+
+countLocalBrapiExportObservations:
+SELECT COUNT(*)
+FROM observations AS obs
+JOIN observation_variables AS vars
+  ON obs.observation_variable_db_id = vars.internal_id_observation_variable
+WHERE obs.study_id = ?
+  AND vars.observation_variable_field_book_format <> 'photo'
+  AND (vars.trait_data_source = 'local' OR vars.trait_data_source IS NULL);
+
+countWrongSourceBrapiExportObservations:
+SELECT COUNT(*)
+FROM observations AS obs
+JOIN observation_variables AS vars
+  ON obs.observation_variable_db_id = vars.internal_id_observation_variable
+WHERE vars.observation_variable_field_book_format <> 'photo'
+  AND vars.trait_data_source <> ?
+  AND vars.trait_data_source <> 'local'
+  AND vars.trait_data_source IS NOT NULL;
+
+updateBrapiExportSyncState:
+UPDATE observations
+SET observation_db_id = ?,
+    last_synced_time = ?
+WHERE internal_id_observation = ?;


### PR DESCRIPTION
Implement current brapi export approach in kmp module:
- use ["photo trait workaround"](https://github.com/PhenoApps/Field-Book/issues/998#issuecomment-2233019062) (edit any brapi imported trait to photo)
- use brapi v2 image endpoints to export

[kmp_brapi_image.webm](https://github.com/user-attachments/assets/c7bda9cd-cd37-4e8c-b37a-0d9cbccdab4f)

#2 