### PR TITLE
IBP-7142 kmp export/import db / pref in xml format / zip in commonMain

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ openapi-generator = "7.22.0"
 lazytable = "1.10.0"
 compass = "1.2.4"
 ksensor = "2.0.4"
+kmp-zip = "0.8.0"
 
 [libraries]
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatform-settings" }
@@ -44,6 +45,7 @@ lazytable = { module = "io.github.oleksandrbalan:lazytable", version.ref = "lazy
 compass-geolocation = { module = "dev.jordond.compass:geolocation", version.ref = "compass" }
 compass-geolocation-mobile = { module = "dev.jordond.compass:geolocation-mobile", version.ref = "compass" }
 ksensor = { module = "io.github.shadmanadman:KSensor", version.ref = "ksensor" }
+kmp-zip = { module = "no.synth:kmp-zip", version.ref = "kmp-zip" }
 
 [plugins]
 app-cash-sqldelight = { id = "app.cash.sqldelight", version = "2.1.0" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -414,6 +414,7 @@ kotlin {
                 implementation(libs.compass.geolocation)
                 implementation(libs.compass.geolocation.mobile)
                 implementation(libs.ksensor)
+                implementation(libs.kmp.zip)
             }
         }
 

--- a/shared/docs/kmp-migration-checklist.md
+++ b/shared/docs/kmp-migration-checklist.md
@@ -174,7 +174,7 @@
 | Define storage location          | :white_check_mark: | :white_check_mark: |
 | Import db (sample)               | :white_check_mark: | :white_check_mark: |
 | Import db (other zip exports)    | :white_check_mark: | :white_check_mark: |
-| Import db (pref file xml)        |                    |                    |
+| Import db (pref file xml)        | :white_check_mark: | :white_check_mark: |
 | Export db                        | :white_check_mark: | :white_check_mark: |
 | Export db (pref file xml)        | :white_check_mark: | :white_check_mark: |
 | Delete db                        | :white_check_mark: | :white_check_mark: |

--- a/shared/docs/kmp-migration-checklist.md
+++ b/shared/docs/kmp-migration-checklist.md
@@ -173,8 +173,10 @@
 | **Settings/Storage**             |                    |                    |
 | Define storage location          | :white_check_mark: | :white_check_mark: |
 | Import db (sample)               | :white_check_mark: | :white_check_mark: |
-| Import db (other file)           |                    |                    |
-| Export db                        |                    |                    |
+| Import db (other zip exports)    | :white_check_mark: | :white_check_mark: |
+| Import db (pref file xml)        |                    |                    |
+| Export db                        | :white_check_mark: | :white_check_mark: |
+| Export db (pref file xml)        | :white_check_mark: | :white_check_mark: |
 | Delete db                        | :white_check_mark: | :white_check_mark: |
 |                                  |                    |                    |
 | **Settings/Experimental**        |                    |                    |

--- a/shared/src/androidMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.android.kt
+++ b/shared/src/androidMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.android.kt
@@ -5,10 +5,7 @@ import android.os.Build
 import com.fieldbook.shared.AndroidAppContextHolder
 import org.jetbrains.compose.resources.StringResource
 import org.phenoapps.utils.BaseDocumentTreeUtil
-import java.io.BufferedInputStream
 import java.io.File
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
 import androidx.documentfile.provider.DocumentFile as AndroidXDocumentFile
 
 class AndroidDocumentFile(val file: AndroidXDocumentFile) : DocumentFile {
@@ -90,51 +87,6 @@ actual fun copyFileToDirectory(source: DocumentFile, destinationDir: DocumentFil
         }
         AndroidDocumentFile(newFile)
     }
-}
-
-actual fun zipFiles(
-    files: List<DocumentFile>,
-    destinationDir: DocumentFile,
-    zipFileName: String
-): DocumentFile? {
-    val ctx = AndroidAppContextHolder.context
-    val dest = destinationDir as? AndroidDocumentFile ?: return null
-    val zipFile = dest.file.createFile("application/zip", "$zipFileName.zip") ?: return null
-
-    ctx.contentResolver.openOutputStream(zipFile.uri)?.use { outputStream ->
-        ZipOutputStream(outputStream).use { zipOutput ->
-            files.forEach { file ->
-                addToZip(zipOutput, file, file.name().orEmpty())
-            }
-        }
-    }
-
-    return AndroidDocumentFile(zipFile)
-}
-
-private fun addToZip(zipOutput: ZipOutputStream, file: DocumentFile, entryName: String) {
-    val androidFile = (file as? AndroidDocumentFile)?.file ?: return
-    val safeEntryName = entryName.trim('/')
-
-    if (androidFile.isDirectory) {
-        val children = androidFile.listFiles()
-        if (children.isEmpty()) {
-            zipOutput.putNextEntry(ZipEntry("$safeEntryName/"))
-            zipOutput.closeEntry()
-        } else {
-            children.forEach { child ->
-                val childName = child.name ?: return@forEach
-                addToZip(zipOutput, AndroidDocumentFile(child), "$safeEntryName/$childName")
-            }
-        }
-        return
-    }
-
-    zipOutput.putNextEntry(ZipEntry(safeEntryName))
-    AndroidAppContextHolder.context.contentResolver.openInputStream(androidFile.uri)?.use { input ->
-        BufferedInputStream(input).copyTo(zipOutput)
-    }
-    zipOutput.closeEntry()
 }
 
 actual fun shareFile(file: DocumentFile) {

--- a/shared/src/androidMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.android.kt
+++ b/shared/src/androidMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.android.kt
@@ -3,11 +3,10 @@ package com.fieldbook.shared.utilities
 import android.content.Intent
 import android.os.Build
 import com.fieldbook.shared.AndroidAppContextHolder
-import com.fieldbook.shared.generated.resources.Res
-import com.fieldbook.shared.generated.resources.dir_field_export
 import org.jetbrains.compose.resources.StringResource
 import org.phenoapps.utils.BaseDocumentTreeUtil
 import java.io.BufferedInputStream
+import java.io.File
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import androidx.documentfile.provider.DocumentFile as AndroidXDocumentFile
@@ -53,6 +52,11 @@ actual fun createDir(parent: String, child: String): DocumentFile? {
     return dir?.let { AndroidDocumentFile(it) }
 }
 
+actual fun getFileByPath(path: String): DocumentFile? {
+    val file = File(path)
+    return if (file.exists()) AndroidDocumentFile(AndroidXDocumentFile.fromFile(file)) else null
+}
+
 actual fun getDirectory(directory: StringResource): DocumentFile? {
     val ctx = AndroidAppContextHolder.context
     val dir = BaseDocumentTreeUtil.getDirectory(
@@ -88,10 +92,14 @@ actual fun copyFileToDirectory(source: DocumentFile, destinationDir: DocumentFil
     }
 }
 
-actual fun zipFiles(files: List<DocumentFile>, zipFileName: String): DocumentFile? {
+actual fun zipFiles(
+    files: List<DocumentFile>,
+    destinationDir: DocumentFile,
+    zipFileName: String
+): DocumentFile? {
     val ctx = AndroidAppContextHolder.context
-    val exportDir = getDirectory(Res.string.dir_field_export) as? AndroidDocumentFile ?: return null
-    val zipFile = exportDir.file.createFile("application/zip", "$zipFileName.zip") ?: return null
+    val dest = destinationDir as? AndroidDocumentFile ?: return null
+    val zipFile = dest.file.createFile("application/zip", "$zipFileName.zip") ?: return null
 
     ctx.contentResolver.openOutputStream(zipFile.uri)?.use { outputStream ->
         ZipOutputStream(outputStream).use { zipOutput ->

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="dialog_enable">Enable</string>
     <string name="dialog_delete">Delete</string>
     <string name="dialog_accept">Accept</string>
+    <string name="dialog_exit">Exit</string>
 
     <string name="barcode_scanner_text">Scan a barcode</string>
 
@@ -94,8 +95,35 @@
     <!-- Changelog -->
     <string name="changelog_title">Changelog</string>
 
+    <!--  Field Grouping  -->
+    <string name="group_archived_value">Archived</string>
+    <string name="fields_ungrouped">Ungrouped</string>
+    <string name="dialog_group_options">Grouping Options</string>
+    <string name="group_existing">Existing group</string>
+    <string name="group_archive">Archive</string>
+    <string name="group_new">New group</string>
+    <string name="group_remove">Remove from group</string>
 
+    <string name="create_new_group">Create New Group</string>
+    <string name="dialog_group_name">Group Name</string>
+    <string name="dialog_group_name_warning">Field cannot be blank</string>
 
+    <string name="menu_group">Group</string>
+    <string name="menu_archive">Archive</string>
+
+    <string name="menu_groups_toggle">Toggle Groups Visibility</string>
+    <string name="group_toggle_icon">Toggle Group</string>
+    <string name="archived_fields">Archived Fields</string>
+    <string name="menu_unarchive">Remove from archive</string>
+    <string name="menu_collapse_all">Collapse All</string>
+    <string name="menu_expand_all">Expand All</string>
+
+    <string name="archive_active_field_title">Archive Active Field?</string>
+    <string name="archive_active_field_message">You have selected the active field to archive. If you continue, there will be no active field. Do you want to continue?</string>
+    <string name="archive_others">Archive Others</string>
+
+    <string name="dialog_unarchive_field_title">Unarchive Field?</string>
+    <string name="dialog_unarchive_field_message">This field is currently archived. If you continue, this field will be unarchived and become the active field. Do you want to continue?</string>
 
 
     <!-- FIELDS -->
@@ -171,6 +199,51 @@
     <string name="dialog_field_creator_ask_size">Please choose a field name and size.</string>
     <string name="dialog_field_creator_ask_start_point">Please choose a field starting point.</string>
     <string name="dialog_field_creator_ask_pattern">Please choose a field pattern.</string>
+    <string name="field_creator_activity_toolbar_title">Create New Field</string>
+    <string name="field_creator_size_title">Field Details</string>
+    <string name="field_creator_start_corner_title">Starting Corner</string>
+    <string name="field_creator_pattern_title">Walking Pattern</string>
+    <string name="field_creator_direction_title">Walking Direction</string>
+    <string name="field_creator_preview_title">Review</string>
+
+    <string name="field_creator_exit_dialog_title">Exit Field Creator</string>
+    <string name="field_creator_exit_dialog_message">Are you sure you want to exit? Your progress will be lost.</string>
+
+    <string name="field_creator_creation_in_progress">Field creation is in progress. Please wait…</string>s
+
+    <string name="field_creator_size_field_name_hint">Field Name</string>
+    <string name="field_creator_size_rows_hint">Rows</string>
+    <string name="field_creator_size_columns_hint">Columns</string>
+
+    <string name="field_name_required_error">Field name is required</string>
+    <string name="field_name_exists_error">Field name already exists</string>
+    <string name="field_creator_positive_number_error">Must be a positive number</string>
+    <string name="field_creator_rows_exceeded_error">Cannot exceed %s</string>
+    <string name="field_creator_cols_exceeded_error">Cannot exceed %s</string>
+    <string name="field_creator_total_plots_exceeded_error">Total plots cannot exceed %1$s. Current total: %2$s</string>
+    <string name="field_creation_failed_error">Failed to create field</string>
+
+    <string name="field_creator_start_point_instruction">Tap a corner to select starting point</string>
+    <string name="field_dimensions_format">Field: %d × %d</string>
+
+    <string name="field_creator_pattern_linear">Linear</string>
+    <string name="field_creator_pattern_linear_summary">Follow same direction after each row/column</string>
+    <string name="field_creator_pattern_zigzag">Serpentine/Zigzag</string>
+    <string name="field_creator_pattern_zigzag_summary">Alternate direction after each row/column</string>
+
+    <string name="field_creator_direction_horizontal">Horizontal</string>
+    <string name="field_creator_direction_horizontal_summary">Walk across rows</string>
+    <string name="field_creator_direction_vertical">Vertical</string>
+    <string name="field_creator_direction_vertical_summary">Walk up/down columns</string>
+
+    <string name="field_creator_preview_summary">Field: %s (%d x %d)</string>
+    <string name="field_creator_preview_large_field_warning">Large field detected. Creating many plots may take some time.</string>
+    <string name="field_creator_preview_creating_field">Creating field…</string>
+    <string name="field_creator_preview_create_button">CREATE</string>
+    <string name="field_creator_preview_expand_button">Expand Grid</string>
+    <string name="field_creator_preview_collapse_button">Collapse Grid</string>
+
+    <string name="field_creator_expanded_preview_title">Full Field Preview</string>
     <string name="dialog_field_creator_ask_name_hint">Name</string>
     <string name="dialog_field_creator_ask_row_hint">Rows</string>
     <string name="dialog_field_creator_ask_columns_hint">Columns</string>
@@ -187,7 +260,17 @@
     <string name="dialog_field_creator_large_field">Large Field Detected, transaction might take a long time.</string>
     <string name="dialog_field_creator_linear_button_content_desc">Button to choose linear plot pattern.</string>
     <string name="dialog_field_creator_zig_button_content_desc">Button to choose zig zag plot pattern.</string>
+    <string name="dialog_field_creator_horizontal_linear_button_content_desc">Button to choose horizontal linear plot pattern.</string>
+    <string name="dialog_field_creator_horizontal_zig_button_content_desc">Button to choose horizontal zig zag plot pattern.</string>
+    <string name="dialog_field_creator_vertical_linear_button_content_desc">Button to choose vertical linear plot pattern.</string>
+    <string name="dialog_field_creator_vertical_zig_button_content_desc">Button to choose vertical zig zag plot pattern.</string>
     <string name="dialog_field_creator_review_image_content_desc">Image showing orientation and plot pattern.</string>
+
+    <string name="field_creator_stepper_size">Size</string>
+    <string name="field_creator_stepper_start">Start Point</string>
+    <string name="field_creator_stepper_pattern">Walking Pattern</string>
+    <string name="field_creator_stepper_direction">Walking Direction</string>
+    <string name="field_creator_stepper_preview">Preview</string>
 
     <!-- Geo-Navigate to Field -->
     <string name="menu_fields_plot_by_distance_title">Select nearest field</string>
@@ -285,6 +368,12 @@
     <string name="traits_format_usb_camera">Usb Camera</string>
     <string name="traits_format_go_pro_camera">GoPro</string>
     <string name="traits_format_angle">Angle</string>
+    <string name="traits_format_spectral">Spectral</string>
+    <string name="traits_format_nix">Nix</string>
+    <string name="traits_format_inno_spectra">InnoSpectra</string>
+    <string name="traits_format_green_seeker">GreenSeeker</string>
+    <string name="traits_format_scale">Scale</string>
+    <string name="traits_format_stop_watch">Stopwatch</string>
 
     <!-- Trait Creation Dialog -->
     <string name="traits_toolbar_add_trait">Trait Format</string>
@@ -304,6 +393,7 @@
     <string name="traits_create_photo_maximum">Maximum number of photos</string>
     <string name="traits_create_true">True</string>
     <string name="traits_create_false">False</string>
+    <string name="traits_create_unset">Unset</string>
     <string name="traits_create_categories_text">Use / to separate categories</string>
     <string name="traits_create_camera">Camera</string>
     <string name="traits_create_close_keyboard">Close Keyboard</string>
@@ -352,6 +442,7 @@
     <string name="main_toolbar_resources">Resources</string>
     <string name="main_trait_details">Trait details</string>
     <string name="main_infobar_data_missing">No data</string>
+    <string name="main_infobar_select_data">Select</string>
     <string name="main_toolbar_next_entry_no_data">Next entry with no data</string>
 
     <!-- InfoBars -->
@@ -408,6 +499,7 @@
     <string name="activity_collect_frozen_state">Frozen - once data is saved it cannot be modified or deleted</string>
     <string name="activity_collect_unlocked_state">Unlocked - no restrictions on data entry, modification, or deletion</string>
 
+    <string name="trait_box_word_wrap_toast">Word wrap %s for traits</string>
     <!-- Trait Layout: Photo -->
     <string name="trait_error_hardware_missing">Your device does not have a camera that can be used to take a photo.</string>
     <string name="trait_delete_warning_photo">Are you sure you want to delete this photo?</string>
@@ -443,6 +535,7 @@
     <!-- Trait Layout: Boolean -->
     <string name="trait_boolean_on">On</string>
     <string name="trait_boolean_off">Off</string>
+    <string name="trait_boolean_unset">Unset</string>
 
     <!-- Trait Layout: GoPro -->
     <string name="trait_go_pro_capture_button_text">Capture\n</string>
@@ -1332,6 +1425,8 @@
     <!-- gopro -->
     <string name="dialog_go_pro_wait_stream_title">Waiting for live preview</string>
     <string name="dialog_go_pro_wait_stream_message">This may take a minute.</string>
+    <string name="view_trait_photo_settings_save_image_title">Copy image to Field Book</string>
+    <string name="go_pro_trait_settings_title">GoPro Settings</string>
 
     <!-- canon camera strings -->
     <string name="canon_frag_connect_btn_content_description">shutter button</string>
@@ -1352,6 +1447,15 @@
     <string name="dialog_brapi_filter_title">Filters</string>
     <string name="dialog_brapi_filter_active">Active</string>
     <string name="dialog_brapi_filter_choices_title">Filter By</string>
+
+    <!-- spectral trait strings -->
+    <string name="trait_spectral_connect_content_description">Starts a device connection.</string>
+    <string name="select_device">Select Device</string>
+    <string name="no_devices_found">No Devices found</string>
+    <string name="list_item_color_close_content_description">Delete this color</string>
+    <string name="delete_color">Delete Color Observation</string>
+    <string name="delete_color_message">This will permanently delete the observation</string>
+    <string name="nix_device_connecting">Device is connecting.</string>
 
     <string name="brapi_studies_filter_title">Studies</string>
     <string name="brapi_trials_filter_title">Trials</string>
@@ -1486,4 +1590,64 @@
     <string name="preferences_preferences_title">Preferences</string>
     <string name="nearby_share_export_preferences">Export Preferences</string>
     <string name="nearby_share_import_preferences">Import Preferences</string>
+    <string name="all_fields_processed">All fields processed</string>
+
+    <string name="spectral_trait_insert_note">Note</string>
+    <string name="spectral_trait_insert_note_message">Write a note for the chosen entry.</string>
+    <string name="trait_spectral_na_content_description">not applicable value placeholder</string>
+    <string name="act_collect_barcode_spectral">Collecting spectral data via barcode input is not supported at this time.</string>
+    <string name="replace_observations">Delete and Replace</string>
+    <string name="replace_observations_message">Observations already exist, would you like to delete these and insert a NA value?</string>
+    <string name="usb_device_description">USB</string>
+    <string name="not_yet_implemented">This feature is not implemented yet.</string>
+    <string name="view_trait_nix_color_option">Color</string>
+    <string name="view_trait_nix_spectral_option">Spectral</string>
+    <string name="nix_trait_settings_title">%s Settings</string>
+    <string name="disconnect">Disconnect</string>
+    <string name="nix_device_incompatible">This device is incompatible, a previous device type already saved data.</string>
+    <string name="nix_error_unknown">"An unknown Nix error occurred. "</string>
+    <string name="nix_error_license">There was an issue with your Nix license or internet connection.</string>
+    <string name="nix_error_ambient_light">Too much ambient light was detected.</string>
+    <string name="nix_error_timeout">A timeout error occurred.</string>
+    <string name="nix_error_low_power">Batteries are too low to scan.</string>
+    <string name="nix_error_scan_not_supported">This scan is not supported by the device.</string>
+    <string name="nix_error_not_ready">The device is not ready.</string>
+    <string name="view_trait_nix_settings_battery_level">Battery Level: %s</string>
+    <string name="view_trait_nix_settings_rssi">RSSI: %s</string>
+    <string name="view_trait_nix_settings_type">Type: %s</string>
+    <string name="view_trait_nix_settings_factory_note">Factory Note: %s</string>
+    <string name="view_trait_nix_settings_serial_number">Serial Number: %s</string>
+    <string name="view_trait_nix_settings_firmware_version">Firmware Version: %s</string>
+    <string name="view_trait_nix_settings_software_version">Software Version: %s</string>
+    <string name="view_trait_nix_settings_external_power_state">External Power State: %s</string>
+    <string name="nix_error_internal">Internal Nix Error</string>
+    <string name="nix_error_invalid_hardware_id">Invalid hardware ID</string>
+    <string name="nix_error_bluetooth_permissions">You must accept bluetooth permissions or try restarting the app.</string>
+    <string name="nix_error_bluetooth_unavailable">Bluetooth is unavailable.</string>
+    <string name="nix_error_bluetooth_disabled">Bluetooth is disabled on the device.</string>
+    <string name="list_item_color_placeholder_content_description">Placeholder for new scan</string>
+    <string name="loading">Loading</string>
+    <string name="nix_error_no_network">Nix may require internet to work properly.</string>
+
+    <string name="import_runnable_field_name_exists">Field name already exists.</string>
+
+    <string name="enabled">enabled</string>
+    <string name="disabled">disabled</string>
+    <string name="logging_out_please_wait">Logging out, please wait.</string>
+
+    <string name="traits_save_image_parameter">Copy image to Field Book</string>
+
+    <!-- Stop Watch Trait Button content descriptions-->
+    <string name="reset">Reset</string>
+    <string name="play">Play</string>
+    <string name="pause">Pause</string>
+    <string name="save">Save</string>
+
+    <string name="database_export_invalid_filename">Invalid export file name.</string>
+    <string name="device_settings_dialog_name">Name: %s</string>
+    <string name="device_settings_dialog_address">Address: %s</string>
+    <string name="device_settings_dialog_unknown_name">Unknown Bluetooth Device</string>
+    <string name="device_settings_dialog_title">Bluetooth Device Settings</string>
+    <string name="no_data_captured">No data captured.</string>
+    <string name="failed_to_find_file_name">Failed to retrieve file name.</string>
 </resources>

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/KmpApp.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/KmpApp.kt
@@ -32,8 +32,6 @@ import com.fieldbook.shared.screens.brapi.trait.brapiTraitImportViewModelFactory
 import com.fieldbook.shared.screens.collect.CollectScreen
 import com.fieldbook.shared.screens.export.ExportScreen
 import com.fieldbook.shared.screens.fields.FieldEditorScreen
-import com.fieldbook.shared.screens.fields.FieldEditorScreenViewModel
-import com.fieldbook.shared.screens.fields.fieldEditorViewModelFactory
 import com.fieldbook.shared.screens.preferences.AppearancePreferencesScreen
 import com.fieldbook.shared.screens.preferences.BrapiPreferencesScreen
 import com.fieldbook.shared.screens.preferences.FeaturePreferenceScreen
@@ -42,8 +40,6 @@ import com.fieldbook.shared.screens.preferences.PreferencesScreen
 import com.fieldbook.shared.screens.preferences.StorageDefinerScreen
 import com.fieldbook.shared.screens.preferences.StoragePreferencesScreen
 import com.fieldbook.shared.screens.trait.TraitEditorScreen
-import com.fieldbook.shared.screens.trait.TraitEditorScreenViewModel
-import com.fieldbook.shared.screens.trait.traitEditorScreenViewModelFactory
 import kotlinx.coroutines.launch
 
 @Composable
@@ -70,12 +66,6 @@ fun KmpApp(
     } else {
         KmpHostScreenType.CONFIG
     }
-    val traitEditorViewModel: TraitEditorScreenViewModel = viewModel(
-        factory = traitEditorScreenViewModelFactory()
-    )
-    val fieldEditorViewModel: FieldEditorScreenViewModel = viewModel(
-        factory = fieldEditorViewModelFactory()
-    )
     val brapiImportSharedViewModel: BrapiImportSharedViewModel = viewModel(
         factory = brapiImportSharedViewModelFactory()
     )
@@ -111,7 +101,6 @@ fun KmpApp(
                 FieldEditorScreen(
                     onBack = { navController.navigateBackOrExit(onExit) },
                     onNavigateToBrapi = { navController.navigateTo(KmpHostScreenType.FIELD_BRAPI) },
-                    viewModel = fieldEditorViewModel,
                     onSnackbarMessage = onSnackbarMessage,
                 )
             }
@@ -133,8 +122,6 @@ fun KmpApp(
                     onBack = { navController.navigateBackOrExit(onExit) },
                     onMissingStudy = { navController.navigateBackOrExit(onExit) },
                     onImportComplete = {
-                        fieldEditorViewModel.loadFields()
-                        traitEditorViewModel.loadTraits()
                         navController.navigateTo(
                             screen = KmpHostScreenType.FIELD_EDITOR,
                             popUpToScreen = KmpHostScreenType.FIELD_EDITOR,
@@ -148,7 +135,6 @@ fun KmpApp(
                 TraitEditorScreen(
                     onBack = { navController.navigateBackOrExit(onExit) },
                     onNavigateToBrapi = { navController.navigateTo(KmpHostScreenType.TRAIT_BRAPI) },
-                    viewModel = traitEditorViewModel,
                     onSnackbarMessage = onSnackbarMessage,
                 )
             }
@@ -158,7 +144,6 @@ fun KmpApp(
                     onBack = { navController.navigateBackOrExit(onExit) },
                     onNavigateToFilter = { navController.navigateTo(KmpHostScreenType.BRAPI_FILTER) },
                     onImportComplete = {
-                        traitEditorViewModel.loadTraits()
                         navController.navigateBackOrExit(onExit)
                     },
                     sharedViewModel = brapiImportSharedViewModel,

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/BrapiObservationSyncSupport.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/BrapiObservationSyncSupport.kt
@@ -7,7 +7,10 @@ import com.fieldbook.shared.database.repository.ExistingBrapiObservation
 import com.fieldbook.shared.database.repository.ObservationRepository
 import com.fieldbook.shared.database.repository.StudyRepository
 import com.fieldbook.shared.database.repository.TraitRepository
+import com.fieldbook.shared.sqldelight.createDatabase
 import com.fieldbook.shared.utilities.currentLocalInternalTimestamp
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 
 data class BrapiObservationSyncPreview(
     val traitCount: Int,
@@ -49,10 +52,10 @@ class BrapiObservationSyncSupport(
         fieldId: Int,
         service: BrAPIService,
         pageSize: Int,
-    ): BrapiResult<BrapiObservationSyncResult> {
+    ): BrapiResult<BrapiObservationSyncResult> = withContext(NonCancellable) {
         val field = studyRepository.getById(fieldId)
         val studyDbId = field.study_db_id.takeIf { it.isNotBlank() }
-            ?: return BrapiResult.Failure(message = "Field is missing BrAPI study id")
+            ?: return@withContext BrapiResult.Failure(message = "Field is missing BrAPI study id")
         val traitByExternalId = traitRepository.getAllTraits()
             .mapNotNull { trait ->
                 val traitId = trait.id ?: return@mapNotNull null
@@ -61,7 +64,7 @@ class BrapiObservationSyncSupport(
             }
             .toMap()
 
-        return when (val result = service.getStudyObservations(studyDbId, traitByExternalId.keys.toList(), pageSize)) {
+        when (val result = service.getStudyObservations(studyDbId, traitByExternalId.keys.toList(), pageSize)) {
             is BrapiResult.Failure -> result
             is BrapiResult.Success -> {
                 val syncResult = saveObservations(fieldId, result.value, traitByExternalId)
@@ -81,60 +84,66 @@ class BrapiObservationSyncSupport(
         observations: List<BrapiObservationImport>,
         traitByExternalId: Map<String, Long>,
     ): BrapiObservationSyncResult {
-        val existingObservations = getExistingObservations(fieldId)
-        val existingDbIds = existingObservations.mapNotNull { it.observationDbId }.toSet()
-        val repBase = existingObservations
-            .groupingBy { it.observationUnitDbId to it.externalTraitDbId }
-            .eachCount()
-            .toMutableMap()
-        val syncTimestamp = currentLocalInternalTimestamp()
-        var saved = 0
-        var skipped = 0
+        var syncResult = BrapiObservationSyncResult(savedObservations = 0, skippedObservations = 0)
 
-        observations
-            .filter { it.canImport }
-            .sortedBy { it.observationTimeStamp.orEmpty() }
-            .forEach { observation ->
-                val observationUnitDbId = observation.observationUnitDbId ?: return@forEach
-                val externalTraitDbId = observation.observationVariableDbId ?: return@forEach
-                val traitId = traitByExternalId[externalTraitDbId] ?: return@forEach
-                val observationDbId = observation.observationDbId
-                val normalizedTimestamp = observation.observationTimeStamp.normalizeBrapiTimestamp()
+        createDatabase().transaction {
+            val existingObservations = getExistingObservations(fieldId)
+            val existingByDbId = existingObservations
+                .mapNotNull { existing -> existing.observationDbId?.let { it to existing } }
+                .toMap()
+            val repBase = existingObservations
+                .groupingBy { it.observationUnitDbId to it.externalTraitDbId }
+                .eachCount()
+                .toMutableMap()
+            val syncTimestamp = currentLocalInternalTimestamp()
+            var saved = 0
+            var skipped = 0
 
-                if (observationDbId != null && observationDbId in existingDbIds) {
-                    val existing = existingObservations.firstOrNull { it.observationDbId == observationDbId }
+            observations
+                .filter { it.canImport }
+                .sortedBy { it.observationTimeStamp.orEmpty() }
+                .forEach { observation ->
+                    val observationUnitDbId = observation.observationUnitDbId ?: return@forEach
+                    val externalTraitDbId = observation.observationVariableDbId ?: return@forEach
+                    val traitId = traitByExternalId[externalTraitDbId] ?: return@forEach
+                    val observationDbId = observation.observationDbId
+                    val normalizedTimestamp = observation.observationTimeStamp.normalizeBrapiTimestamp()
+
+                    val existing = observationDbId?.let(existingByDbId::get)
                     if (existing?.timestamp.isSameOrAfter(normalizedTimestamp) == true) {
                         skipped++
                         return@forEach
                     }
+
+                    val repKey = observationUnitDbId to externalTraitDbId
+                    val nextRep = (repBase[repKey] ?: 0) + 1
+                    repBase[repKey] = nextRep
+
+                    if (hasObservation(fieldId, observationUnitDbId, traitId, nextRep.toString())) {
+                        skipped++
+                        return@forEach
+                    }
+
+                    insertObservation(
+                        fieldId = fieldId,
+                        observation = observation,
+                        traitId = traitId,
+                        observationTimeStamp = normalizedTimestamp,
+                        lastSyncedTime = syncTimestamp,
+                        rep = nextRep.toString(),
+                    )
+                    saved++
                 }
 
-                val repKey = observationUnitDbId to externalTraitDbId
-                val nextRep = (repBase[repKey] ?: 0) + 1
-                repBase[repKey] = nextRep
+            studyRepository.updateSyncDate(fieldId, syncTimestamp)
 
-                if (hasObservation(fieldId, observationUnitDbId, traitId, nextRep.toString())) {
-                    skipped++
-                    return@forEach
-                }
+            syncResult = BrapiObservationSyncResult(
+                savedObservations = saved,
+                skippedObservations = skipped,
+            )
+        }
 
-                insertObservation(
-                    fieldId = fieldId,
-                    observation = observation,
-                    traitId = traitId,
-                    observationTimeStamp = normalizedTimestamp,
-                    lastSyncedTime = syncTimestamp,
-                    rep = nextRep.toString(),
-                )
-                saved++
-            }
-
-        studyRepository.updateSyncDate(fieldId, syncTimestamp)
-
-        return BrapiObservationSyncResult(
-            savedObservations = saved,
-            skippedObservations = skipped,
-        )
+        return syncResult
     }
 
     private fun insertObservation(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldDetailScreen.kt
@@ -136,6 +136,8 @@ fun FieldDetailScreen(
     var showSearchDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showBrapiSyncDialog by remember { mutableStateOf(false) }
+    var brapiSyncSubmitted by remember { mutableStateOf(false) }
+    var brapiSyncSaveStarted by remember { mutableStateOf(false) }
     var searchAttributeOptions by remember { mutableStateOf<List<String>>(emptyList()) }
 
     LaunchedEffect(fieldId) {
@@ -153,6 +155,16 @@ fun FieldDetailScreen(
             searchAttributeOptions = withContext(Dispatchers.Default) {
                 viewModel.getPossibleUniqueAttributes(fieldId)
             }
+        }
+    }
+
+    LaunchedEffect(brapiSyncSubmitted, brapiSyncSaving) {
+        if (brapiSyncSubmitted && brapiSyncSaving) {
+            brapiSyncSaveStarted = true
+        } else if (brapiSyncSubmitted && brapiSyncSaveStarted && !brapiSyncSaving) {
+            showBrapiSyncDialog = false
+            brapiSyncSubmitted = false
+            brapiSyncSaveStarted = false
         }
     }
 
@@ -453,8 +465,12 @@ fun FieldDetailScreen(
                     saving = brapiSyncSaving,
                     preview = brapiSyncPreview,
                     onDismiss = {
-                        showBrapiSyncDialog = false
-                        viewModel.clearBrapiObservationSync()
+                        if (!brapiSyncSaving) {
+                            showBrapiSyncDialog = false
+                            brapiSyncSubmitted = false
+                            brapiSyncSaveStarted = false
+                            viewModel.clearBrapiObservationSync()
+                        }
                     },
                     onSave = {
                         currentField.exp_id?.let {
@@ -462,8 +478,8 @@ fun FieldDetailScreen(
                                 fieldId = it,
                                 defaultBrapiBaseUrl = defaultBrapiBaseUrl,
                             )
+                            brapiSyncSubmitted = true
                         }
-                        showBrapiSyncDialog = false
                     }
                 )
             }
@@ -512,7 +528,10 @@ private fun BrapiObservationSyncDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(
+                enabled = !saving,
+                onClick = onDismiss
+            ) {
                 Text(stringResource(Res.string.dialog_cancel))
             }
         }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldEditorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/fields/FieldEditorScreen.kt
@@ -838,8 +838,8 @@ class FieldEditorScreenViewModel(
     }
 
     fun syncBrapiObservations(fieldId: Int, defaultBrapiBaseUrl: String) {
+        _brapiSyncSaving.value = true
         viewModelScope.launch {
-            _brapiSyncSaving.value = true
             try {
                 when (val result = brapiObservationSyncSupport.sync(
                     fieldId = fieldId,

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/StoragePreferencesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/StoragePreferencesScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -24,7 +25,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,8 +33,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.fieldbook.shared.database.utils.DATABASE_NAME
-import com.fieldbook.shared.database.utils.importDatabaseFromBundled
 import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.database_dialog_title
 import com.fieldbook.shared.generated.resources.database_export
@@ -55,6 +53,8 @@ import com.fieldbook.shared.generated.resources.ic_pref_database_delete
 import com.fieldbook.shared.generated.resources.ic_pref_database_export
 import com.fieldbook.shared.generated.resources.ic_pref_database_import
 import com.fieldbook.shared.generated.resources.ic_pref_general_root_directory
+import com.fieldbook.shared.generated.resources.import_dialog_importing
+import com.fieldbook.shared.generated.resources.import_error_general
 import com.fieldbook.shared.generated.resources.preferences_storage_database_title
 import com.fieldbook.shared.generated.resources.preferences_storage_files_base_directory_description
 import com.fieldbook.shared.generated.resources.preferences_storage_files_base_directory_title
@@ -63,11 +63,14 @@ import com.fieldbook.shared.generated.resources.preferences_storage_title
 import com.fieldbook.shared.preferences.GeneralKeys
 import com.fieldbook.shared.theme.AlertDialog
 import com.fieldbook.shared.theme.TextButton
+import com.fieldbook.shared.utilities.DatabaseImportResult
+import com.fieldbook.shared.utilities.DocumentFile
+import com.fieldbook.shared.utilities.availableDatabaseImportFiles
 import com.fieldbook.shared.utilities.defaultDatabaseExportFileName
 import com.fieldbook.shared.utilities.displayStorageDirectoryPath
 import com.fieldbook.shared.utilities.exportDatabaseZip
+import com.fieldbook.shared.utilities.importDatabaseFile
 import com.fieldbook.shared.utilities.resetLocalDatabaseAndPreferences
-import com.fieldbook.shared.utilities.selectFirstField
 import com.fieldbook.shared.utilities.shareFile
 import com.russhwolf.settings.Settings
 import kotlinx.coroutines.Dispatchers
@@ -100,8 +103,7 @@ fun StoragePreferencesScreen(
     var isImporting by remember { mutableStateOf(false) }
     var isExporting by remember { mutableStateOf(false) }
     var exportFileName by remember { mutableStateOf("") }
-    var importResult by remember { mutableStateOf<String?>(null) }
-    var showSuccessSnackbar by remember { mutableStateOf(false) }
+    var importFiles by remember { mutableStateOf<List<DocumentFile>>(emptyList()) }
     val coroutineScope = rememberCoroutineScope()
     val settings = remember { Settings() }
     val storageDirectorySummary = displayStorageDirectoryPath(
@@ -112,6 +114,7 @@ fun StoragePreferencesScreen(
     val deleteFailureMessage = "Failed to delete database."
     val exportCompleteMessage = stringResource(Res.string.export_complete)
     val exportErrorMessage = stringResource(Res.string.export_error_general)
+    val importErrorMessage = stringResource(Res.string.import_error_general)
     val invalidExportFileNameMessage = stringResource(Res.string.database_export_invalid_filename)
 
     val storageItems = listOf(
@@ -220,7 +223,10 @@ fun StoragePreferencesScreen(
                                 .padding(16.dp)
                                 .clickable {
                                     when (item.key) {
-                                        "pref_database_import" -> showImportDialog = true
+                                        "pref_database_import" -> {
+                                            importFiles = availableDatabaseImportFiles()
+                                            showImportDialog = true
+                                        }
                                         "pref_database_export" -> {
                                             exportFileName = defaultDatabaseExportFileName()
                                             showExportDialog = true
@@ -248,35 +254,54 @@ fun StoragePreferencesScreen(
                     onDismissRequest = {
                         showImportDialog = false
                         isImporting = false
-                        importResult = null
                     },
                     title = { Text(text = stringResource(Res.string.database_import)) },
                     text = {
-                        Column {
-                            if (!isImporting && importResult == null) {
-                                TextButton(
-                                    onClick = {
-                                        coroutineScope.launch {
-                                            isImporting = true
-                                            importResult = null
-                                            try {
-                                                importDatabaseFromBundled(
-                                                    DATABASE_NAME
-                                                )
-                                                selectFirstField()
-                                                showImportDialog = false
-                                                showSuccessSnackbar = true
-                                            } catch (e: Exception) {
-                                                importResult =
-                                                    "Failed to import sample database: ${'$'}{e.message}"
-                                            } finally {
-                                                isImporting = false
-                                            }
+                        when {
+                            isImporting -> Text(stringResource(Res.string.import_dialog_importing))
+                            importFiles.isEmpty() -> Text("No database backups found.")
+                            else -> {
+                                LazyColumn(modifier = Modifier.heightIn(max = 320.dp)) {
+                                    items(importFiles) { file ->
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .clickable(enabled = !isImporting) {
+                                                    coroutineScope.launch {
+                                                        isImporting = true
+                                                        try {
+                                                            val result = withContext(Dispatchers.Default) {
+                                                                importDatabaseFile(file)
+                                                            }
+
+                                                            when (result) {
+                                                                DatabaseImportResult.Success -> {
+                                                                    showImportDialog = false
+                                                                    onSnackbarMessage("Database imported successfully.")
+                                                                }
+
+                                                                DatabaseImportResult.NoDatabaseFile,
+                                                                DatabaseImportResult.UnsupportedFile -> {
+                                                                    onSnackbarMessage(importErrorMessage)
+                                                                }
+                                                            }
+                                                        } catch (_: Exception) {
+                                                            onSnackbarMessage(importErrorMessage)
+                                                        } finally {
+                                                            isImporting = false
+                                                        }
+                                                    }
+                                                }
+                                                .padding(vertical = 12.dp),
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            Text(
+                                                text = file.name().orEmpty(),
+                                                style = MaterialTheme.typography.bodyLarge
+                                            )
                                         }
-                                    },
-                                    enabled = !isImporting
-                                ) {
-                                    Text("sample_db")
+                                        Divider()
+                                    }
                                 }
                             }
                         }
@@ -286,7 +311,6 @@ fun StoragePreferencesScreen(
                             onClick = {
                                 showImportDialog = false
                                 isImporting = false
-                                importResult = null
                             }
                         ) {
                             Text(stringResource(Res.string.dialog_cancel))
@@ -352,12 +376,6 @@ fun StoragePreferencesScreen(
                         }
                     }
                 )
-            }
-            if (showSuccessSnackbar) {
-                LaunchedEffect(showSuccessSnackbar) {
-                    onSnackbarMessage("Sample database imported successfully.")
-                    showSuccessSnackbar = false
-                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/StoragePreferencesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/StoragePreferencesScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -35,17 +36,21 @@ import androidx.compose.ui.unit.dp
 import com.fieldbook.shared.database.utils.DATABASE_NAME
 import com.fieldbook.shared.database.utils.importDatabaseFromBundled
 import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.database_dialog_title
 import com.fieldbook.shared.generated.resources.database_export
+import com.fieldbook.shared.generated.resources.database_export_invalid_filename
 import com.fieldbook.shared.generated.resources.database_import
 import com.fieldbook.shared.generated.resources.database_reset
-import com.fieldbook.shared.generated.resources.database_reset_message
 import com.fieldbook.shared.generated.resources.database_reset_warning1
 import com.fieldbook.shared.generated.resources.database_reset_warning2
 import com.fieldbook.shared.generated.resources.dialog_cancel
 import com.fieldbook.shared.generated.resources.dialog_delete
 import com.fieldbook.shared.generated.resources.dialog_no
+import com.fieldbook.shared.generated.resources.dialog_save
 import com.fieldbook.shared.generated.resources.dialog_warning
 import com.fieldbook.shared.generated.resources.dialog_yes
+import com.fieldbook.shared.generated.resources.export_complete
+import com.fieldbook.shared.generated.resources.export_error_general
 import com.fieldbook.shared.generated.resources.ic_pref_database_delete
 import com.fieldbook.shared.generated.resources.ic_pref_database_export
 import com.fieldbook.shared.generated.resources.ic_pref_database_import
@@ -56,14 +61,18 @@ import com.fieldbook.shared.generated.resources.preferences_storage_files_base_d
 import com.fieldbook.shared.generated.resources.preferences_storage_storage_title
 import com.fieldbook.shared.generated.resources.preferences_storage_title
 import com.fieldbook.shared.preferences.GeneralKeys
-import com.fieldbook.shared.screens.export.ExportScreen
 import com.fieldbook.shared.theme.AlertDialog
 import com.fieldbook.shared.theme.TextButton
+import com.fieldbook.shared.utilities.defaultDatabaseExportFileName
 import com.fieldbook.shared.utilities.displayStorageDirectoryPath
+import com.fieldbook.shared.utilities.exportDatabaseZip
 import com.fieldbook.shared.utilities.resetLocalDatabaseAndPreferences
 import com.fieldbook.shared.utilities.selectFirstField
+import com.fieldbook.shared.utilities.shareFile
 import com.russhwolf.settings.Settings
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
@@ -89,6 +98,8 @@ fun StoragePreferencesScreen(
     var showDeleteWarning1 by remember { mutableStateOf(false) }
     var showDeleteWarning2 by remember { mutableStateOf(false) }
     var isImporting by remember { mutableStateOf(false) }
+    var isExporting by remember { mutableStateOf(false) }
+    var exportFileName by remember { mutableStateOf("") }
     var importResult by remember { mutableStateOf<String?>(null) }
     var showSuccessSnackbar by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
@@ -98,8 +109,10 @@ fun StoragePreferencesScreen(
         settings.getString(GeneralKeys.DEFAULT_STORAGE_LOCATION_PROVIDER_TYPE.key, ""),
         settings.getString(GeneralKeys.DEFAULT_STORAGE_LOCATION_PROVIDER_LABEL.key, "")
     )
-    val deleteSuccessMessage = stringResource(Res.string.database_reset_message)
     val deleteFailureMessage = "Failed to delete database."
+    val exportCompleteMessage = stringResource(Res.string.export_complete)
+    val exportErrorMessage = stringResource(Res.string.export_error_general)
+    val invalidExportFileNameMessage = stringResource(Res.string.database_export_invalid_filename)
 
     val storageItems = listOf(
         StoragePreferenceItem(
@@ -208,7 +221,10 @@ fun StoragePreferencesScreen(
                                 .clickable {
                                     when (item.key) {
                                         "pref_database_import" -> showImportDialog = true
-                                        "pref_database_export" -> showExportDialog = true
+                                        "pref_database_export" -> {
+                                            exportFileName = defaultDatabaseExportFileName()
+                                            showExportDialog = true
+                                        }
                                         "pref_database_delete" -> showDeleteWarning1 = true
                                     }
                                 },
@@ -347,9 +363,63 @@ fun StoragePreferencesScreen(
     }
 
     if (showExportDialog) {
-        ExportScreen(
-            fieldIds = emptyList(),
-            onBack = { showExportDialog = false }
+        AlertDialog(
+            onDismissRequest = {
+                if (!isExporting) {
+                    showExportDialog = false
+                }
+            },
+            title = { Text(stringResource(Res.string.database_dialog_title)) },
+            text = {
+                OutlinedTextField(
+                    value = exportFileName,
+                    onValueChange = { exportFileName = it },
+                    enabled = !isExporting,
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        val requestedFileName = exportFileName.trim()
+                        if (requestedFileName.isBlank()) {
+                            onSnackbarMessage(invalidExportFileNameMessage)
+                            return@Button
+                        }
+
+                        coroutineScope.launch {
+                            isExporting = true
+                            try {
+                                runCatching {
+                                    withContext(Dispatchers.Default) {
+                                        exportDatabaseZip(requestedFileName)
+                                    }
+                                }.onSuccess { exportedFile ->
+                                    showExportDialog = false
+                                    shareFile(exportedFile)
+                                    onSnackbarMessage(exportCompleteMessage)
+                                }.onFailure {
+                                    onSnackbarMessage(exportErrorMessage)
+                                }
+                            } finally {
+                                isExporting = false
+                            }
+                        }
+                    },
+                    enabled = !isExporting
+                ) {
+                    Text(stringResource(Res.string.dialog_save))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showExportDialog = false },
+                    enabled = !isExporting
+                ) {
+                    Text(stringResource(Res.string.dialog_cancel))
+                }
+            }
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitEditorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitEditorScreen.kt
@@ -133,6 +133,10 @@ fun TraitEditorScreen(
     }
     val scope = rememberCoroutineScope()
 
+    LaunchedEffect(Unit) {
+        viewModel.loadTraits()
+    }
+
     val importFilePicker = rememberFilePickerLauncher(
         type = PickerType.File(extensions = listOf("trt")),
         title = "Import trait file"

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitEditorScreenViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/trait/TraitEditorScreenViewModel.kt
@@ -66,10 +66,6 @@ class TraitEditorScreenViewModel(
     private val _messages = MutableSharedFlow<String>()
     val messages = _messages.asSharedFlow()
 
-    init {
-        loadTraits()
-    }
-
     fun loadTraits() {
         viewModelScope.launch {
             _loading.value = true

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseExportUtil.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseExportUtil.kt
@@ -6,6 +6,7 @@ import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.dir_database
 import com.fieldbook.shared.sqldelight.FieldbookDatabase
 import com.fieldbook.shared.sqldelight.closeDatabase
+import com.russhwolf.settings.Settings
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -41,10 +42,68 @@ fun exportDatabaseZip(fileName: String): DocumentFile {
         ?: error("Database file was not found.")
     val databaseDir = getDirectory(Res.string.dir_database)
         ?: error("Database export directory was not found.")
+    val preferencesFile = createPreferencesBackupFile(databaseDir)
+        ?: error("Unable to create preferences backup.")
 
-    return zipFiles(
-        files = listOf(databaseFile),
-        destinationDir = databaseDir,
-        zipFileName = normalizedFileName
-    ) ?: error("Unable to create database export.")
+    return try {
+        zipFiles(
+            files = listOf(databaseFile, preferencesFile),
+            destinationDir = databaseDir,
+            zipFileName = normalizedFileName
+        ) ?: error("Unable to create database export.")
+    } finally {
+        runCatching { deleteFile(preferencesFile) }
+    }
 }
+
+private fun createPreferencesBackupFile(databaseDir: DocumentFile): DocumentFile? {
+    val fileName = "preferences_backup_${Clock.System.now().toEpochMilliseconds()}.xml"
+    return databaseDir.createFile("text/xml", fileName)?.also { file ->
+        file.writeBytes(createPreferencesXml().encodeToByteArray())
+    }
+}
+
+private fun createPreferencesXml(settings: Settings = Settings()): String {
+    val entries = settings.keys.sorted().mapNotNull { key ->
+        preferenceXmlEntry(settings, key)
+    }
+
+    return buildString {
+        appendLine("""<?xml version="1.0" encoding="utf-8" standalone="yes"?>""")
+        appendLine("<map>")
+        entries.forEach { entry ->
+            appendLine("    $entry")
+        }
+        appendLine("</map>")
+    }
+}
+
+private fun preferenceXmlEntry(settings: Settings, key: String): String? {
+    runCatching { settings.getStringOrNull(key) }.getOrNull()?.let { value ->
+        return """<string name="${escapeXmlAttribute(key)}">${escapeXmlText(value)}</string>"""
+    }
+
+    runCatching { settings.getBooleanOrNull(key) }.getOrNull()?.let { value ->
+        return """<boolean name="${escapeXmlAttribute(key)}" value="$value" />"""
+    }
+
+    runCatching { settings.getIntOrNull(key) }.getOrNull()?.let { value ->
+        return """<int name="${escapeXmlAttribute(key)}" value="$value" />"""
+    }
+
+    return null
+}
+
+private fun escapeXmlAttribute(value: String): String =
+    value
+        .replace("&", "&amp;")
+        .replace("\"", "&quot;")
+        .replace("'", "&apos;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+
+private fun escapeXmlText(value: String): String =
+    value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseExportUtil.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseExportUtil.kt
@@ -1,0 +1,50 @@
+package com.fieldbook.shared.utilities
+
+import com.fieldbook.shared.database.utils.DATABASE_NAME
+import com.fieldbook.shared.database.utils.PlatformEnv
+import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.dir_database
+import com.fieldbook.shared.sqldelight.FieldbookDatabase
+import com.fieldbook.shared.sqldelight.closeDatabase
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+fun defaultDatabaseExportFileName(): String {
+    val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+    val hour = now.hour.mod(12).let { if (it == 0) 12 else it }
+
+    return buildString {
+        append(now.year.toString().padStart(4, '0'))
+        append("-")
+        append(now.monthNumber.toString().padStart(2, '0'))
+        append("-")
+        append(now.dayOfMonth.toString().padStart(2, '0'))
+        append("-")
+        append(hour.toString().padStart(2, '0'))
+        append("-")
+        append(now.minute.toString().padStart(2, '0'))
+        append("-")
+        append(now.second.toString().padStart(2, '0'))
+        append("_systemdb")
+        append(FieldbookDatabase.Schema.version)
+    }
+}
+
+fun exportDatabaseZip(fileName: String): DocumentFile {
+    val normalizedFileName = fileName.trim().removeSuffix(".zip")
+    require(normalizedFileName.isNotBlank()) { "Invalid export file name." }
+
+    closeDatabase()
+
+    val databaseFile = getFileByPath(PlatformEnv.databaseFilePath(DATABASE_NAME))
+        ?: error("Database file was not found.")
+    val databaseDir = getDirectory(Res.string.dir_database)
+        ?: error("Database export directory was not found.")
+
+    return zipFiles(
+        files = listOf(databaseFile),
+        destinationDir = databaseDir,
+        zipFileName = normalizedFileName
+    ) ?: error("Unable to create database export.")
+}

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseImportUtil.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseImportUtil.kt
@@ -1,0 +1,81 @@
+package com.fieldbook.shared.utilities
+
+import com.fieldbook.shared.database.utils.DATABASE_NAME
+import com.fieldbook.shared.database.utils.PlatformEnv
+import com.fieldbook.shared.database.utils.writeAllBytes
+import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.dir_database
+import com.fieldbook.shared.preferences.GeneralKeys
+import com.russhwolf.settings.Settings
+import no.synth.kmpzip.zip.ZipInputStream
+
+sealed class DatabaseImportResult {
+    data object Success : DatabaseImportResult()
+    data object NoDatabaseFile : DatabaseImportResult()
+    data object UnsupportedFile : DatabaseImportResult()
+}
+
+
+fun availableDatabaseImportFiles(): List<DocumentFile> {
+    val databaseDir = getDirectory(Res.string.dir_database) ?: return emptyList()
+    return listFiles(databaseDir)
+        .filter { file ->
+            file.name()?.let { name ->
+                name.endsWith(".db", ignoreCase = true) ||
+                    name.endsWith(".zip", ignoreCase = true)
+            } ?: false
+        }
+        .sortedBy { it.name().orEmpty().lowercase() }
+}
+
+fun importDatabaseFile(file: DocumentFile): DatabaseImportResult {
+    val name = file.name().orEmpty()
+    return when {
+        name.endsWith(".db", ignoreCase = true) -> {
+            importDatabaseBytes(file.readBytes())
+            clearImportedDatabaseState()
+            selectFirstField()
+            DatabaseImportResult.Success
+        }
+
+        name.endsWith(".zip", ignoreCase = true) -> importDatabaseZip(file.readBytes())
+        else -> DatabaseImportResult.UnsupportedFile
+    }
+}
+
+private fun importDatabaseZip(bytes: ByteArray): DatabaseImportResult {
+    var databaseBytes: ByteArray? = null
+
+    ZipInputStream(bytes).use { zipInput ->
+        while (true) {
+            val entry = zipInput.nextEntry ?: break
+            val entryName = entry.name
+            val entryBytes = zipInput.readBytes()
+            zipInput.closeEntry()
+
+            when {
+                entryName == DATABASE_NAME || entryName == "Output/$DATABASE_NAME" -> {
+                    databaseBytes = entryBytes
+                }
+            }
+        }
+    }
+
+    val database = databaseBytes ?: return DatabaseImportResult.NoDatabaseFile
+    importDatabaseBytes(database)
+    selectFirstField()
+    return DatabaseImportResult.Success
+}
+
+private fun importDatabaseBytes(bytes: ByteArray) {
+    writeAllBytes(PlatformEnv.databaseFilePath(DATABASE_NAME), bytes)
+}
+
+private fun clearImportedDatabaseState(settings: Settings = Settings()) {
+    settings.putInt(GeneralKeys.SELECTED_FIELD_ID.key, -1)
+    settings.putString(GeneralKeys.UNIQUE_NAME.key, "")
+    settings.putString(GeneralKeys.PRIMARY_NAME.key, "")
+    settings.putString(GeneralKeys.SECONDARY_NAME.key, "")
+    settings.putBoolean(GeneralKeys.IMPORT_FIELD_FINISHED.key, false)
+}
+

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseImportUtil.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseImportUtil.kt
@@ -45,6 +45,7 @@ fun importDatabaseFile(file: DocumentFile): DatabaseImportResult {
 
 private fun importDatabaseZip(bytes: ByteArray): DatabaseImportResult {
     var databaseBytes: ByteArray? = null
+    var importedPreferences = false
 
     ZipInputStream(bytes).use { zipInput ->
         while (true) {
@@ -57,19 +58,106 @@ private fun importDatabaseZip(bytes: ByteArray): DatabaseImportResult {
                 entryName == DATABASE_NAME || entryName == "Output/$DATABASE_NAME" -> {
                     databaseBytes = entryBytes
                 }
+
+                entryName.endsWith(".xml", ignoreCase = true) -> {
+                    updatePreferences(readPreferencesXml(entryBytes))
+                    importedPreferences = true
+                }
             }
         }
     }
 
     val database = databaseBytes ?: return DatabaseImportResult.NoDatabaseFile
     importDatabaseBytes(database)
-    selectFirstField()
+    if (!importedPreferences) {
+        selectFirstField()
+    }
     return DatabaseImportResult.Success
 }
 
 private fun importDatabaseBytes(bytes: ByteArray) {
     writeAllBytes(PlatformEnv.databaseFilePath(DATABASE_NAME), bytes)
 }
+
+private sealed interface ImportedPreferenceValue {
+    data class BooleanValue(val value: Boolean) : ImportedPreferenceValue
+    data class IntValue(val value: Int) : ImportedPreferenceValue
+    data class StringValue(val value: String) : ImportedPreferenceValue
+    data object Unsupported : ImportedPreferenceValue
+}
+
+private fun updatePreferences(
+    prefMap: Map<String, ImportedPreferenceValue>,
+    settings: Settings = Settings(),
+) {
+    settings.clear()
+    prefMap.forEach { (key, value) ->
+        when (value) {
+            is ImportedPreferenceValue.BooleanValue -> settings.putBoolean(key, value.value)
+            is ImportedPreferenceValue.IntValue -> settings.putInt(key, value.value)
+            is ImportedPreferenceValue.StringValue -> settings.putString(key, value.value)
+            ImportedPreferenceValue.Unsupported -> Unit
+        }
+    }
+}
+
+private fun readPreferencesXml(bytes: ByteArray): Map<String, ImportedPreferenceValue> {
+    val xml = bytes.decodeToString()
+    val mapStart = Regex("""<map\b[^>]*>""").find(xml)?.range?.last?.plus(1) ?: 0
+    val mapEnd = xml.lastIndexOf("</map>").takeIf { it >= mapStart } ?: xml.length
+    val body = xml.substring(mapStart, mapEnd)
+    val preferences = mutableMapOf<String, ImportedPreferenceValue>()
+
+    preferenceElementRegex.findAll(body).forEach { match ->
+        val tagName = match.groupValues[1]
+        val attributes = readXmlAttributes(match.groupValues[2])
+        val name = attributes["name"] ?: return@forEach
+
+        when (tagName) {
+            "string" -> {
+                val value = match.groups[3]?.value.orEmpty().trim().decodeXmlEntities()
+                preferences[name] = ImportedPreferenceValue.StringValue(value)
+            }
+
+            "boolean" -> {
+                attributes["value"]?.let { value ->
+                    preferences[name] = ImportedPreferenceValue.BooleanValue(value.toBoolean())
+                }
+            }
+
+            "int" -> {
+                attributes["value"]?.toIntOrNull()?.let { value ->
+                    preferences[name] = ImportedPreferenceValue.IntValue(value)
+                }
+            }
+
+            "set" -> {
+                preferences[name] = ImportedPreferenceValue.Unsupported
+            }
+        }
+    }
+
+    return preferences
+}
+
+private val preferenceElementRegex =
+    Regex("""<([A-Za-z][A-Za-z0-9_-]*)\b([^>]*)(?:/>|>(.*?)</\1>)""", RegexOption.DOT_MATCHES_ALL)
+
+private val xmlAttributeRegex =
+    Regex("""([A-Za-z_:][A-Za-z0-9_:.-]*)\s*=\s*("[^"]*"|'[^']*')""")
+
+private fun readXmlAttributes(attributes: String): Map<String, String> =
+    xmlAttributeRegex.findAll(attributes).associate { match ->
+        val valueWithQuotes = match.groupValues[2]
+        match.groupValues[1] to valueWithQuotes.substring(1, valueWithQuotes.length - 1).decodeXmlEntities()
+    }
+
+private fun String.decodeXmlEntities(): String =
+    replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
 
 private fun clearImportedDatabaseState(settings: Settings = Settings()) {
     settings.putInt(GeneralKeys.SELECTED_FIELD_ID.key, -1)
@@ -78,4 +166,3 @@ private fun clearImportedDatabaseState(settings: Settings = Settings()) {
     settings.putString(GeneralKeys.SECONDARY_NAME.key, "")
     settings.putBoolean(GeneralKeys.IMPORT_FIELD_FINISHED.key, false)
 }
-

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseImportUtil.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DatabaseImportUtil.kt
@@ -108,10 +108,10 @@ private fun readPreferencesXml(bytes: ByteArray): Map<String, ImportedPreference
     val body = xml.substring(mapStart, mapEnd)
     val preferences = mutableMapOf<String, ImportedPreferenceValue>()
 
-    preferenceElementRegex.findAll(body).forEach { match ->
+    preferenceElementRegex.findEach(body) { match ->
         val tagName = match.groupValues[1]
         val attributes = readXmlAttributes(match.groupValues[2])
-        val name = attributes["name"] ?: return@forEach
+        val name = attributes["name"] ?: return@findEach
 
         when (tagName) {
             "string" -> {
@@ -141,16 +141,34 @@ private fun readPreferencesXml(bytes: ByteArray): Map<String, ImportedPreference
 }
 
 private val preferenceElementRegex =
-    Regex("""<([A-Za-z][A-Za-z0-9_-]*)\b([^>]*)(?:/>|>(.*?)</\1>)""", RegexOption.DOT_MATCHES_ALL)
+    Regex("""<([A-Za-z][A-Za-z0-9_-]*)\b([^>]*)(?:/>|>([\s\S]*?)</\1>)""")
 
 private val xmlAttributeRegex =
     Regex("""([A-Za-z_:][A-Za-z0-9_:.-]*)\s*=\s*("[^"]*"|'[^']*')""")
 
 private fun readXmlAttributes(attributes: String): Map<String, String> =
-    xmlAttributeRegex.findAll(attributes).associate { match ->
-        val valueWithQuotes = match.groupValues[2]
-        match.groupValues[1] to valueWithQuotes.substring(1, valueWithQuotes.length - 1).decodeXmlEntities()
+    buildMap {
+        xmlAttributeRegex.findEach(attributes) { match ->
+            val valueWithQuotes = match.groupValues[2]
+            put(
+                match.groupValues[1],
+                valueWithQuotes.substring(1, valueWithQuotes.length - 1).decodeXmlEntities(),
+            )
+        }
     }
+
+private inline fun Regex.findEach(input: CharSequence, action: (MatchResult) -> Unit) {
+    var startIndex = 0
+    while (startIndex <= input.length) {
+        val match = find(input, startIndex) ?: break
+        action(match)
+        startIndex = if (match.range.isEmpty()) {
+            match.range.last + 2
+        } else {
+            match.range.last + 1
+        }
+    }
+}
 
 private fun String.decodeXmlEntities(): String =
     replace("&lt;", "<")

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.kt
@@ -1,5 +1,8 @@
 package com.fieldbook.shared.utilities
 
+import no.synth.kmpzip.io.ByteArrayOutputStream
+import no.synth.kmpzip.zip.ZipEntry
+import no.synth.kmpzip.zip.ZipOutputStream
 import org.jetbrains.compose.resources.StringResource
 
 interface DocumentFile {
@@ -21,7 +24,44 @@ expect fun getFileByPath(path: String): DocumentFile?
 expect fun getDirectory(directory: StringResource): DocumentFile?
 expect fun listFiles(dir: DocumentFile): List<DocumentFile>
 expect fun copyFileToDirectory(source: DocumentFile, destinationDir: DocumentFile, newFileName: String): DocumentFile?
-expect fun zipFiles(files: List<DocumentFile>, destinationDir: DocumentFile, zipFileName: String): DocumentFile?
 expect fun shareFile(file: DocumentFile)
 expect fun deleteFile(file: DocumentFile)
 expect fun exportDeviceName(): String
+
+fun zipFiles(files: List<DocumentFile>, destinationDir: DocumentFile, zipFileName: String): DocumentFile? {
+    val outputName = if (zipFileName.endsWith(".zip")) zipFileName else "$zipFileName.zip"
+    val zipFile = destinationDir.createFile("application/zip", outputName) ?: return null
+    val zipBytes = ByteArrayOutputStream().use { byteOutput ->
+        ZipOutputStream(byteOutput).use { zipOutput ->
+            files.forEach { file ->
+                addToZip(zipOutput, file, file.name().orEmpty())
+            }
+        }
+        byteOutput.toByteArray()
+    }
+    zipFile.writeBytes(zipBytes)
+    return zipFile
+}
+
+private fun addToZip(zipOutput: ZipOutputStream, file: DocumentFile, entryName: String) {
+    val safeEntryName = entryName.trim('/').takeIf { it.isNotBlank() } ?: return
+
+    if (file.isDirectory()) {
+        val children = listFiles(file)
+        if (children.isEmpty()) {
+            zipOutput.putNextEntry(ZipEntry("$safeEntryName/"))
+            zipOutput.closeEntry()
+        } else {
+            children.forEach { child ->
+                val childName = child.name() ?: return@forEach
+                addToZip(zipOutput, child, "$safeEntryName/$childName")
+            }
+        }
+        return
+    }
+
+    val bytes = file.readBytes()
+    zipOutput.putNextEntry(ZipEntry(safeEntryName))
+    zipOutput.write(bytes, 0, bytes.size)
+    zipOutput.closeEntry()
+}

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.kt
@@ -16,11 +16,12 @@ interface DocumentFile {
 }
 
 expect fun createDir(parent: String, child: String): DocumentFile?
+expect fun getFileByPath(path: String): DocumentFile?
 
 expect fun getDirectory(directory: StringResource): DocumentFile?
 expect fun listFiles(dir: DocumentFile): List<DocumentFile>
 expect fun copyFileToDirectory(source: DocumentFile, destinationDir: DocumentFile, newFileName: String): DocumentFile?
-expect fun zipFiles(files: List<DocumentFile>, zipFileName: String): DocumentFile?
+expect fun zipFiles(files: List<DocumentFile>, destinationDir: DocumentFile, zipFileName: String): DocumentFile?
 expect fun shareFile(file: DocumentFile)
 expect fun deleteFile(file: DocumentFile)
 expect fun exportDeviceName(): String

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/ExportUtil.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/utilities/ExportUtil.kt
@@ -238,7 +238,9 @@ class ExportUtil : CoroutineScope by MainScope() {
         val finalFile = try {
             val generatedFiles = pendingExport.generatedFiles.toList()
             val file = if (generatedFiles.size > 1) {
-                zipFiles(generatedFiles, options.fileName)
+                val exportDir = getDirectory(Res.string.dir_field_export)
+                    ?: return ExportResult.Failure(IllegalStateException("Field export directory not found"))
+                zipFiles(generatedFiles, exportDir, options.fileName)
             } else {
                 generatedFiles.firstOrNull()
             } ?: return ExportResult.Failure(IllegalStateException("Failed to create export file"))

--- a/shared/src/iosMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.ios.kt
+++ b/shared/src/iosMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.ios.kt
@@ -215,19 +215,6 @@ actual fun copyFileToDirectory(source: DocumentFile, destinationDir: DocumentFil
     }
 }
 
-actual fun zipFiles(
-    files: List<DocumentFile>,
-    destinationDir: DocumentFile,
-    zipFileName: String
-): DocumentFile? {
-    val bundleDir = destinationDir.createDirectory("$zipFileName.export") ?: return null
-    files.forEach { file ->
-        val name = file.name() ?: return@forEach
-        copyFileToDirectory(file, bundleDir, name)
-    }
-    return bundleDir
-}
-
 @OptIn(BetaInteropApi::class)
 actual fun shareFile(file: DocumentFile) {
     val iosFile = file as? IosDocumentFile ?: return

--- a/shared/src/iosMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.ios.kt
+++ b/shared/src/iosMain/kotlin/com/fieldbook/shared/utilities/DocumentFile.ios.kt
@@ -2,8 +2,6 @@
 
 package com.fieldbook.shared.utilities
 
-import com.fieldbook.shared.generated.resources.Res
-import com.fieldbook.shared.generated.resources.dir_field_export
 import com.fieldbook.shared.preferences.GeneralKeys
 import com.russhwolf.settings.Settings
 import kotlinx.cinterop.BetaInteropApi
@@ -178,6 +176,9 @@ actual fun createDir(
     return directoryPath.takeIf { ensureDirectoryExists(it) }?.let(::IosDocumentFile)
 }
 
+actual fun getFileByPath(path: String): DocumentFile? =
+    path.takeIf(fileManager::fileExistsAtPath)?.let(::IosDocumentFile)
+
 actual fun getDirectory(directory: StringResource): DocumentFile? =
     IosDocumentFile(directoryPath(directory))
 
@@ -214,9 +215,12 @@ actual fun copyFileToDirectory(source: DocumentFile, destinationDir: DocumentFil
     }
 }
 
-actual fun zipFiles(files: List<DocumentFile>, zipFileName: String): DocumentFile? {
-    val exportDir = getDirectory(Res.string.dir_field_export) ?: return null
-    val bundleDir = exportDir.createDirectory("$zipFileName.export") ?: return null
+actual fun zipFiles(
+    files: List<DocumentFile>,
+    destinationDir: DocumentFile,
+    zipFileName: String
+): DocumentFile? {
+    val bundleDir = destinationDir.createDirectory("$zipFileName.export") ?: return null
     files.forEach { file ->
         val name = file.name() ?: return@forEach
         copyFileToDirectory(file, bundleDir, name)


### PR DESCRIPTION
#2 

- export db as zip
  - Fieldbook.db
  - preferences (xml format)
- move zip logic to commonMain using `kmp-zip`: enable zip in ios (main collect export and export db)
- update strings.xml from main app
- show db zip to import from database folder, besides sample_db
  - import pref xml format
- fix reset trait list after db import
- small fix to not cancel sync obs when navigate 

Native Field-Book android can import the pref xml format, but import the serialized java blob format in kmp is **not supported** .

Export db:

<img width="1080" height="2400" alt="Screenshot_20260515_133410" src="https://github.com/user-attachments/assets/d036ea7d-5d4b-47f2-9a5c-16ef14ecc7bd" />

Import:

[db_import.webm](https://github.com/user-attachments/assets/4c1de916-c07f-4091-b3a9-27398ae854e2)
