### PR TITLE
Ibp 7142 kmp ios build kotlin 2 3 10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,6 @@ apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'androidx.navigation.safeargs'
 apply plugin: 'com.google.dagger.hilt.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
-apply plugin: 'com.google.devtools.ksp'
 apply plugin: "org.jetbrains.kotlin.plugin.serialization"
 apply plugin: "kotlin-parcelize"
 
@@ -230,9 +229,9 @@ dependencies {
     implementation 'androidx.documentfile:documentfile:1.1.0'
 
     //hilt dependency injection
-    implementation "com.google.dagger:hilt-android:2.56.2"
+    implementation "com.google.dagger:hilt-android:2.58"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
-    ksp "com.google.dagger:hilt-compiler:2.56.2"
+    kapt "com.google.dagger:hilt-compiler:2.58"
 
     implementation 'com.google.mlkit:barcode-scanning:17.3.0'
 
@@ -327,9 +326,9 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
 
     // For instrumented tests.
-    androidTestImplementation 'com.google.dagger:hilt-android-testing:2.56.2'
+    androidTestImplementation 'com.google.dagger:hilt-android-testing:2.58'
     // ...with Kotlin.
-    kspAndroidTest 'com.google.dagger:hilt-android-compiler:2.56.2'
+    kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.58'
 
     // For trait data charts
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'

--- a/app/src/main/java/com/fieldbook/tracker/utilities/connectivity/ScaleGattManager.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/connectivity/ScaleGattManager.kt
@@ -146,7 +146,7 @@ class ScaleGattManager @Inject constructor(
                     return
                 }
 
-                //Log.d("GATT", "${value.toList().map { it.toChar() }}")
+                //Log.d("GATT", "${value.toList().map { it.toInt().toChar() }}")
 
                 byteBuffer.addAll(value.toList())
 
@@ -156,7 +156,7 @@ class ScaleGattManager @Inject constructor(
 //              val byteHexes = byteBuffer.joinToString(", ") { String.format("0x%02X", it) }
 //              Log.d("GATT", "Received complete message: ${byteHexes}")
                     //convert bytes to char and log
-                    val charValues = byteBuffer.map { it.toChar() }
+                    val charValues = byteBuffer.map { it.toInt().toChar() }
 //              Log.d("GATT", "Received complete message as chars: ${charValues.joinToString("")}")
                     val weightString = charValues.joinToString("").dropLast(2) // Drop the last CRLF characters
                     val pattern = Regex(
@@ -184,7 +184,7 @@ class ScaleGattManager @Inject constructor(
 
         private fun handleCraneScaleWeightCharacteristic(characteristic: BluetoothGattCharacteristic) {
 
-            val stringValue = characteristic.value?.joinToString("") { it.toChar().toString() }
+            val stringValue = characteristic.value?.joinToString("") { it.toInt().toChar().toString() }
 
             stringValue?.let { weightString ->
 
@@ -212,14 +212,14 @@ class ScaleGattManager @Inject constructor(
             //log as hex values
             //Log.d("GATT", "Characteristic changed: ${characteristic.uuid}, Value (Hex): ${value?.joinToString(", ") { String.format("0x%02X", it) }}")
             //log as string
-            val stringValue = value?.joinToString("") { it.toChar().toString() }
+            val stringValue = value?.joinToString("") { it.toInt().toChar().toString() }
             //log as integer
             //Log.d("Scale", "Characteristic changed: ${characteristic.uuid}, Value Length: ${value?.size}, Value (String): $stringValue")
 
             listener?.logUnknownScaleBytes(
                 characteristic.service.uuid.toString(),
                 characteristic.uuid.toString(),
-                (value?.joinToString("") { it.toChar().toString() }
+                (value?.joinToString("") { it.toInt().toChar().toString() }
                         + " "
                         +value?.joinToString(", ") { String.format("0x%02X", it) })
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,19 +10,18 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.9.3'
         classpath 'com.google.gms:google-services:4.4.3'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.10"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.10"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.9.3"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.56'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.58'
     }
 }
 
 plugins {
-    id 'com.google.dagger.hilt.android' version '2.56' apply false
-    id 'org.jetbrains.kotlin.android' version '2.2.10' apply false
-    id "org.jetbrains.kotlin.plugin.compose" version "2.1.10"
-    id 'org.jetbrains.kotlin.kapt' version '2.2.10' apply false
-    id 'com.google.devtools.ksp' version '2.2.10-2.0.2' apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22" apply false
+    id 'com.google.dagger.hilt.android' version '2.58' apply false
+    id 'org.jetbrains.kotlin.android' version '2.3.10' apply false
+    id "org.jetbrains.kotlin.plugin.compose" version "2.3.10"
+    id 'org.jetbrains.kotlin.kapt' version '2.3.10' apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.3.10" apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-kotlin-plugin-compose = "2.1.10" # same as main app build.gradle
+kotlin-plugin-compose = "2.3.10" # same as main app build.gradle
 compose = "1.7.3" # compatible with compileSdk = 34
 multiplatform-settings = "1.3.0"
 lifecycle-viewmodel-compose = "2.8.4" # compatible with compose
 navigation-compose = "2.8.0-alpha11" # aligned with Compose Multiplatform 1.7.3
 kotlinx-datetime = "0.6.2" # When upgrading, see https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant
-kotlinx-serialization = "1.9.22" # same as main app build.gradle
+kotlinx-serialization = "2.3.10" # same as main app build.gradle
 kotlinx-serialization-json = "1.8.1"
 okio = "2.2.0"
 filekit = "0.8.8" # compatible with compileSdk = 34

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -420,7 +420,7 @@ kotlin {
 
         commonTest {
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-test:2.1.10")
+                implementation("org.jetbrains.kotlin:kotlin-test:2.3.10")
             }
         }
 


### PR DESCRIPTION
### Description

This PR fixes the iOS build failure on branch `IBP-7142-kmp` caused by a Kotlin Native ABI mismatch with `no.synth:kmp-zip`.

To resolve it, the project toolchain was aligned to Kotlin `2.3.10`, shared dependency versions were updated accordingly, and Android build compatibility was preserved by updating Hilt to a version compatible with Kotlin `2.3.x` and the current AGP version. This PR also includes a small Android source update to replace deprecated `Byte.toChar()` conversions that became build-blocking after the Kotlin upgrade.

Validated with:
- `./gradlew :shared:compileKotlinIosArm64`
- `./gradlew :app:compileDebugKotlin`

### Change Type

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [x] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

```release-note
Updated the Kotlin and shared build configuration so the app builds successfully on both iOS and Android again.