### PR TITLE
Ibp 7142 kmp audio and disease rating traits

### DIFF
--- a/shared/src/androidMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTraitPlatform.android.kt
+++ b/shared/src/androidMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTraitPlatform.android.kt
@@ -1,0 +1,134 @@
+package com.fieldbook.shared.screens.collect.traits
+
+import android.media.MediaMetadataRetriever
+import android.media.MediaPlayer
+import android.media.MediaRecorder
+import android.net.Uri
+import com.fieldbook.shared.AndroidAppContextHolder
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.math.ceil
+import kotlin.math.ln
+import kotlin.math.pow
+
+actual class PlatformAudioController {
+    private var mediaRecorder: MediaRecorder? = null
+    private var mediaPlayer: MediaPlayer? = null
+
+    actual fun startRecording(outputUri: String): Boolean {
+        return try {
+            stopPlayback()
+            mediaRecorder?.release()
+            mediaRecorder = MediaRecorder()
+            val uri = Uri.parse(outputUri)
+            val fd = AndroidAppContextHolder.context.contentResolver
+                .openFileDescriptor(uri, "rw")
+                ?.fileDescriptor
+                ?: return false
+
+            mediaRecorder?.apply {
+                setAudioSource(MediaRecorder.AudioSource.MIC)
+                setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+                setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
+                setOutputFile(fd)
+                prepare()
+                start()
+            }
+            true
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    actual fun stopRecording() {
+        try {
+            mediaRecorder?.stop()
+        } catch (_: Throwable) {
+        } finally {
+            mediaRecorder?.release()
+            mediaRecorder = null
+        }
+    }
+
+    actual fun startPlayback(inputUri: String, onPlaybackCompleted: () -> Unit): Boolean {
+        return try {
+            stopPlayback()
+            val uri = Uri.parse(inputUri)
+            mediaPlayer = MediaPlayer.create(AndroidAppContextHolder.context, uri)?.apply {
+                setOnCompletionListener {
+                    stopPlayback()
+                    onPlaybackCompleted()
+                }
+                start()
+            }
+            mediaPlayer != null
+        } catch (_: Throwable) {
+            stopPlayback()
+            false
+        }
+    }
+
+    actual fun stopPlayback() {
+        try {
+            mediaPlayer?.stop()
+        } catch (_: Throwable) {
+        } finally {
+            mediaPlayer?.reset()
+            mediaPlayer?.release()
+            mediaPlayer = null
+        }
+    }
+
+    actual fun dispose() {
+        stopRecording()
+        stopPlayback()
+    }
+}
+
+actual fun inspectAudioTraitFile(uri: String): AudioTraitMetadata? {
+    return try {
+        val ctx = AndroidAppContextHolder.context
+        val parsed = Uri.parse(uri)
+        val document = androidx.documentfile.provider.DocumentFile.fromSingleUri(ctx, parsed)
+        val lastModified = document?.lastModified() ?: 0L
+        val fileSize = document?.length() ?: 0L
+        val duration = MediaMetadataRetriever().use { retriever ->
+            retriever.setDataSource(ctx, parsed)
+            val millis = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                ?.toLongOrNull()
+                ?: 0L
+            formatDurationMillis(millis)
+        }
+
+        AudioTraitMetadata(
+            timestamp = SimpleDateFormat("MMM d, yyyy | h:mm a", Locale.getDefault()).format(Date(lastModified)),
+            duration = duration,
+            fileSize = formatFileSize(fileSize)
+        )
+    } catch (_: Throwable) {
+        null
+    }
+}
+
+private inline fun <T : AutoCloseable?, R> T.use(block: (T) -> R): R {
+    return try {
+        block(this)
+    } finally {
+        this?.close()
+    }
+}
+
+private fun formatDurationMillis(durationMillis: Long): String {
+    val totalSeconds = ceil(durationMillis / 1000.0).toLong()
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return "%02d:%02d".format(minutes, seconds)
+}
+
+private fun formatFileSize(bytes: Long): String {
+    if (bytes < 1024L) return "$bytes B"
+    val exponent = (ln(bytes.toDouble()) / ln(1024.0)).toInt()
+    val prefix = "KMGTPE"[exponent - 1].toString()
+    return "%.2f %sB".format(bytes / 1024.0.pow(exponent.toDouble()), prefix)
+}

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectInput.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectInput.kt
@@ -31,6 +31,9 @@ import com.fieldbook.shared.screens.collect.traits.BooleanTrait
 import com.fieldbook.shared.screens.collect.traits.CategoricalTrait
 import com.fieldbook.shared.screens.collect.traits.CounterTrait
 import com.fieldbook.shared.screens.collect.traits.DateTrait
+import com.fieldbook.shared.screens.collect.traits.DiseaseRatingTrait
+import com.fieldbook.shared.screens.collect.traits.AngleTrait
+import com.fieldbook.shared.screens.collect.traits.AudioTrait
 import com.fieldbook.shared.screens.collect.traits.LocationTrait
 import com.fieldbook.shared.screens.collect.traits.NumericTrait
 import com.fieldbook.shared.screens.collect.traits.PercentTrait
@@ -154,6 +157,26 @@ fun CollectInput(
                     )
                 }
             }
+        } else if (formatEnum == Formats.AUDIO) {
+            TraitInputContainer(
+                usesLazyVerticalInput = false,
+                scrollable = false,
+                centerContent = false,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            ) {
+                key(currentPlotId, currentTraitId) {
+                    TraitInputHost(
+                        controller = controller,
+                        trait = trait,
+                        values = values,
+                        onEdited = { isEdited = true },
+                        modifier = Modifier.fillMaxWidth(),
+                        onExpandPhotoTrait = onExpandPhotoTrait
+                    )
+                }
+            }
         } else {
             Text(
                 text = displayValue,
@@ -195,6 +218,7 @@ fun CollectInput(
 private fun TraitInputContainer(
     usesLazyVerticalInput: Boolean,
     scrollable: Boolean = true,
+    centerContent: Boolean = !scrollable,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
@@ -206,11 +230,11 @@ private fun TraitInputContainer(
                 Modifier.verticalScroll(rememberScrollState())
             }
         ),
-        contentAlignment = if (scrollable) Alignment.TopCenter else Alignment.Center
+        contentAlignment = if (centerContent) Alignment.Center else Alignment.TopCenter
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = if (scrollable) Arrangement.Top else Arrangement.Center,
+            verticalArrangement = if (centerContent) Arrangement.Center else Arrangement.Top,
             modifier = if (usesLazyVerticalInput || !scrollable) {
                 Modifier.fillMaxSize()
             } else {
@@ -232,6 +256,7 @@ fun TraitInputHost(
     onExpandPhotoTrait: () -> Unit = {},
 ) {
     val value = values.firstOrNull() ?: ""
+    val normalizedTraitFormat = trait?.format?.trim().orEmpty()
     val formatEnum = trait?.format?.let { formatStr ->
         Formats.entries.find { it.databaseName.equals(formatStr, ignoreCase = true) }
     }
@@ -306,12 +331,32 @@ fun TraitInputHost(
             modifier = modifier.fillMaxWidth().padding(8.dp)
         )
 
+        Formats.AUDIO -> AudioTrait(
+            value = value,
+            onValueChange = {
+                controller.updateCurrentTraitValue(it)
+                onEdited()
+            },
+            controller = controller,
+            modifier = modifier.fillMaxWidth().padding(8.dp)
+        )
+
         Formats.DATE -> DateTrait(
             value = value,
             onValueChange = {
                 controller.updateCurrentTraitValue(it)
                 onEdited()
             },
+            modifier = modifier.fillMaxWidth().padding(8.dp)
+        )
+
+        Formats.DISEASE_RATING -> DiseaseRatingTrait(
+            value = value,
+            onValueChange = {
+                controller.updateCurrentTraitValue(it)
+                onEdited()
+            },
+            onValidationError = { },
             modifier = modifier.fillMaxWidth().padding(8.dp)
         )
 
@@ -341,10 +386,22 @@ fun TraitInputHost(
             )
         }
 
-        else -> NotImplementedTrait(
-            traitFormat = trait?.format ?: "unknown",
-            modifier = modifier.fillMaxWidth().padding(8.dp)
-        )
+        else -> when (normalizedTraitFormat.lowercase()) {
+            "disease", "disease_rating", "disease rating", "rust rating" -> DiseaseRatingTrait(
+                value = value,
+                onValueChange = {
+                    controller.updateCurrentTraitValue(it)
+                    onEdited()
+                },
+                onValidationError = { },
+                modifier = modifier.fillMaxWidth().padding(8.dp)
+            )
+
+            else -> NotImplementedTrait(
+                traitFormat = trait?.format ?: "unknown",
+                modifier = modifier.fillMaxWidth().padding(8.dp)
+            )
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
@@ -107,14 +107,20 @@ fun CollectScreen(
                 title = { Text(text = "Collect Data") },
                 navigationIcon = {
                     if (onBack != null) {
-                        IconButton(onClick = handleBack) {
+                        IconButton(
+                            onClick = handleBack,
+                            enabled = !controller.collectInteractionLocked
+                        ) {
                             Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
                         }
                     }
                 },
                 actions = {
                     if (dataGridEnabled) {
-                        IconButton(onClick = { showDataGrid = true }) {
+                        IconButton(
+                            onClick = { showDataGrid = true },
+                            enabled = !controller.collectInteractionLocked
+                        ) {
                             Icon(
                                 painter = painterResource(Res.drawable.ic_field),
                                 contentDescription = "Data Grid"

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
@@ -60,6 +60,8 @@ class CollectScreenController {
     private var lastUnitId: String? = null
     private var restoredUnitSelection = false
     private var restoredTraitSelection = false
+    var collectInteractionLocked by mutableStateOf(false)
+        private set
 
     val primaryId = settings.getString(GeneralKeys.PRIMARY_NAME.key, "")
     val secondaryId = settings.getString(GeneralKeys.SECONDARY_NAME.key, "")
@@ -259,6 +261,9 @@ class CollectScreenController {
         return Color(storedArgb)
     }
 
+    fun updateCollectInteractionLocked(locked: Boolean) {
+        collectInteractionLocked = locked
+    }
     fun persistCurrentSelection() {
         currentRangeUniqueId()?.let {
             settings.putString(lastPlotKey(), it)

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/RangeBox.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/RangeBox.kt
@@ -68,7 +68,7 @@ fun RangeBox(
         ) {
             IconButton(
                 onClick = { controller.updateCurrentUnitIndex(controller.currentUnitIndex - 1) },
-                enabled = controller.currentUnitIndex > 0,
+                enabled = !controller.collectInteractionLocked && controller.currentUnitIndex > 0,
                 modifier = Modifier.size(56.dp)
             ) {
                 Icon(
@@ -98,7 +98,7 @@ fun RangeBox(
             }
             IconButton(
                 onClick = { controller.updateCurrentUnitIndex(controller.currentUnitIndex + 1) },
-                enabled = controller.currentUnitIndex < controller.units.size - 1,
+                enabled = !controller.collectInteractionLocked && controller.currentUnitIndex < controller.units.size - 1,
                 modifier = Modifier.size(56.dp)
             ) {
                 Icon(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/TraitBox.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/TraitBox.kt
@@ -34,7 +34,7 @@ fun TraitBox(
         ) {
             IconButton(
                 onClick = { viewModel.updateCurrentTraitIndex(viewModel.currentTraitIndex - 1) },
-                enabled = viewModel.currentTraitIndex > 0,
+                enabled = !viewModel.collectInteractionLocked && viewModel.currentTraitIndex > 0,
                 modifier = Modifier.size(56.dp)
             ) {
                 Icon(
@@ -52,7 +52,7 @@ fun TraitBox(
             )
             IconButton(
                 onClick = { viewModel.updateCurrentTraitIndex(viewModel.currentTraitIndex + 1) },
-                enabled = viewModel.currentTraitIndex < viewModel.traits.size - 1,
+                enabled = !viewModel.collectInteractionLocked && viewModel.currentTraitIndex < viewModel.traits.size - 1,
                 modifier = Modifier.size(56.dp)
             ) {
                 Icon(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTrait.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTrait.kt
@@ -1,0 +1,286 @@
+package com.fieldbook.shared.screens.collect.traits
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.trait_audio_button_content_description
+import com.fieldbook.shared.generated.resources.trait_audio_duration
+import com.fieldbook.shared.generated.resources.trait_audio_file_size
+import com.fieldbook.shared.generated.resources.trait_audio_placeholder_filename
+import com.fieldbook.shared.generated.resources.trait_audio
+import com.fieldbook.shared.generated.resources.trait_audio_play
+import com.fieldbook.shared.generated.resources.trait_audio_stop
+import com.fieldbook.shared.generated.resources.trait_audio_timestamp
+import com.fieldbook.shared.screens.collect.CollectScreenController
+import com.fieldbook.shared.utilities.DocumentTreeUtil
+import com.fieldbook.shared.utilities.currentLocalInternalTimestamp
+import com.fieldbook.shared.utilities.deleteFile
+import com.fieldbook.shared.utilities.sanitizeFileName
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+private enum class AudioButtonState {
+    WAITING_FOR_RECORDING,
+    RECORDING,
+    WAITING_FOR_PLAYBACK,
+    PLAYING
+}
+
+@Composable
+fun AudioTrait(
+    value: String,
+    onValueChange: (String) -> Unit,
+    controller: CollectScreenController,
+    modifier: Modifier = Modifier,
+) {
+    val audioController = remember { PlatformAudioController() }
+    var buttonState by remember { mutableStateOf(AudioButtonState.WAITING_FOR_RECORDING) }
+    var recordedUri by remember { mutableStateOf(value.takeUnless { it == "NA" }.orEmpty()) }
+    var metadata by remember { mutableStateOf<AudioTraitMetadata?>(null) }
+
+    fun currentTraitName(): String {
+        return controller.traits
+            .getOrNull(controller.currentTraitIndex)
+            ?.name
+            ?.takeIf { it.isNotBlank() }
+            ?: "audio"
+    }
+
+    fun buildAudioFileName(): String {
+        val plotId = controller.units.getOrNull(controller.currentUnitIndex)?.observation_unit_db_id
+            ?.takeIf { it.isNotBlank() }
+            ?: "audio"
+        val traitName = sanitizeFileName(currentTraitName())
+        val timestamp = sanitizeFileName(currentLocalInternalTimestamp())
+        return "${sanitizeFileName(plotId)}_${traitName}_$timestamp.mp4"
+    }
+
+    fun createAudioTargetUri(): String? {
+        val directory = DocumentTreeUtil.getFieldMediaDirectory(currentTraitName()) ?: return null
+        val file = directory.createFile("audio/mp4", buildAudioFileName()) ?: return null
+        return file.uri()
+    }
+
+    fun deleteStoredAudio(uri: String) {
+        val fileName = uri.substringBefore("?").substringAfterLast("/").replace("%20", " ")
+        val directory = DocumentTreeUtil.getFieldMediaDirectory(currentTraitName()) ?: return
+        directory.findFile(fileName)?.let(::deleteFile)
+    }
+
+    LaunchedEffect(value) {
+        if (buttonState == AudioButtonState.RECORDING || buttonState == AudioButtonState.PLAYING) {
+            return@LaunchedEffect
+        }
+
+        if (value == "NA") {
+            recordedUri = ""
+            metadata = null
+            buttonState = AudioButtonState.WAITING_FOR_RECORDING
+        } else {
+            recordedUri = value
+            metadata = value.takeIf { it.isNotBlank() }?.let(::inspectAudioTraitFile)
+            buttonState = if (value.isNotBlank()) {
+                AudioButtonState.WAITING_FOR_PLAYBACK
+            } else {
+                AudioButtonState.WAITING_FOR_RECORDING
+            }
+        }
+    }
+
+    LaunchedEffect(buttonState) {
+        controller.updateCollectInteractionLocked(
+            buttonState == AudioButtonState.RECORDING || buttonState == AudioButtonState.PLAYING
+        )
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            audioController.dispose()
+            controller.updateCollectInteractionLocked(false)
+        }
+    }
+
+    fun stopPlayback() {
+        audioController.stopPlayback()
+        buttonState = if (recordedUri.isNotBlank()) {
+            AudioButtonState.WAITING_FOR_PLAYBACK
+        } else {
+            AudioButtonState.WAITING_FOR_RECORDING
+        }
+    }
+
+    fun stopRecording() {
+        audioController.stopRecording()
+        if (recordedUri.isNotBlank()) {
+            metadata = inspectAudioTraitFile(recordedUri)
+            buttonState = AudioButtonState.WAITING_FOR_PLAYBACK
+        } else {
+            buttonState = AudioButtonState.WAITING_FOR_RECORDING
+        }
+    }
+
+    fun startPlayback() {
+        val uri = recordedUri.takeIf { it.isNotBlank() } ?: return
+        if (audioController.startPlayback(uri) {
+                buttonState = AudioButtonState.WAITING_FOR_PLAYBACK
+            }
+        ) {
+            buttonState = AudioButtonState.PLAYING
+        }
+    }
+
+    fun startRecording() {
+        if (recordedUri.isNotBlank()) {
+            deleteStoredAudio(recordedUri)
+            recordedUri = ""
+            metadata = null
+            onValueChange("")
+        }
+        val targetUri = createAudioTargetUri() ?: return
+        if (audioController.startRecording(targetUri)) {
+            recordedUri = targetUri
+            buttonState = AudioButtonState.RECORDING
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (value == "NA") {
+            AudioInfoCard(
+                title = "NA",
+                metadata = null
+            )
+        } else if (recordedUri.isNotBlank() && metadata != null) {
+            AudioInfoCard(
+                title = stringResource(Res.string.trait_audio_placeholder_filename),
+                metadata = metadata
+            )
+        }
+
+        if (recordedUri.isNotBlank() || value == "NA") {
+            Spacer(modifier = Modifier.size(16.dp))
+        }
+
+        FloatingActionButton(
+            onClick = {
+                when (buttonState) {
+                    AudioButtonState.WAITING_FOR_RECORDING -> startRecording()
+                    AudioButtonState.RECORDING -> {
+                        stopRecording()
+                        if (recordedUri.isNotBlank()) {
+                            onValueChange(recordedUri)
+                        }
+                    }
+                    AudioButtonState.WAITING_FOR_PLAYBACK -> startPlayback()
+                    AudioButtonState.PLAYING -> stopPlayback()
+                }
+            },
+            shape = CircleShape,
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(96.dp)
+        ) {
+            Icon(
+                painter = painterResource(
+                    when (buttonState) {
+                        AudioButtonState.WAITING_FOR_RECORDING -> Res.drawable.trait_audio
+                        AudioButtonState.RECORDING -> Res.drawable.trait_audio_stop
+                        AudioButtonState.WAITING_FOR_PLAYBACK -> Res.drawable.trait_audio_play
+                        AudioButtonState.PLAYING -> Res.drawable.trait_audio_stop
+                    }
+                ),
+                contentDescription = stringResource(Res.string.trait_audio_button_content_description),
+                modifier = Modifier.size(42.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun AudioInfoCard(
+    title: String,
+    metadata: AudioTraitMetadata?,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+
+            if (metadata != null) {
+                Text(
+                    text = "${stringResource(Res.string.trait_audio_timestamp)}${metadata.timestamp}",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "${stringResource(Res.string.trait_audio_duration)}${metadata.duration}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = "${stringResource(Res.string.trait_audio_file_size)}${metadata.fileSize}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            } else {
+                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTraitPlatform.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTraitPlatform.kt
@@ -1,0 +1,17 @@
+package com.fieldbook.shared.screens.collect.traits
+
+data class AudioTraitMetadata(
+    val timestamp: String,
+    val duration: String,
+    val fileSize: String,
+)
+
+expect class PlatformAudioController() {
+    fun startRecording(outputUri: String): Boolean
+    fun stopRecording()
+    fun startPlayback(inputUri: String, onPlaybackCompleted: () -> Unit): Boolean
+    fun stopPlayback()
+    fun dispose()
+}
+
+expect fun inspectAudioTraitFile(uri: String): AudioTraitMetadata?

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/DiseaseRatingTrait.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/DiseaseRatingTrait.kt
@@ -1,41 +1,167 @@
 package com.fieldbook.shared.screens.collect.traits
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.dp
+import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.dir_trait
+import com.fieldbook.shared.generated.resources.trait_error_disease_severity
 import com.fieldbook.shared.theme.Button
-import com.fieldbook.shared.theme.numericButtonDefaults
+import com.fieldbook.shared.utilities.getDirectory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.stringResource
+
+private val fallbackRustCodes = listOf(
+    "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50",
+    "55", "60", "65", "70", "75", "80", "85", "90", "95", "100"
+)
+private val rustNumericButtonWidth = 62.dp
+private val rustLetterButtonWidth = 86.dp
+private val rustButtonHeight = 52.dp
+private val rustNumericTextStyle = TextStyle(fontSize = 13.sp)
+private val rustLetterTextStyle = TextStyle(fontSize = 16.sp)
+private val rustButtonContentPadding = PaddingValues(horizontal = 2.dp, vertical = 0.dp)
+
+@OptIn(ExperimentalResourceApi::class)
+private suspend fun loadRustCodes(): List<String> = withContext(Dispatchers.Default) {
+    val fromStorage = runCatching {
+        getDirectory(Res.string.dir_trait)
+            ?.findFile("severity.txt")
+            ?.takeIf { it.exists() }
+            ?.readBytes()
+            ?.decodeToString()
+            ?.split(Regex("\\s+"))
+            ?.map { it.trim() }
+            ?.filter { it.isNotBlank() }
+            ?.take(21)
+            ?.takeIf { it.isNotEmpty() }
+    }.getOrNull()
+
+    fromStorage
+        ?: runCatching {
+            Res.readBytes("files/trait/severity.txt")
+                .decodeToString()
+                .split(Regex("\\s+"))
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .take(21)
+                .takeIf { it.isNotEmpty() }
+        }.getOrNull()
+        ?: fallbackRustCodes
+}
+
+private fun appendDiseaseRatingValue(currentValue: String, pressedValue: String): String? {
+    if (currentValue.isNotEmpty() &&
+        pressedValue != "/" &&
+        !currentValue.endsWith("/")
+    ) {
+        val lastChar = currentValue.last()
+        if (!lastChar.isLetter()) {
+            return currentValue + ":" + pressedValue
+        }
+    }
+
+    return currentValue + pressedValue
+}
 
 @Composable
 fun DiseaseRatingTrait(
     value: String,
     onValueChange: (String) -> Unit,
-    modifier: Modifier = Modifier
+    onValidationError: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    var current by remember(value) { mutableStateOf(value.toIntOrNull() ?: 0) }
-    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-        Row(horizontalArrangement = Arrangement.Center, modifier = Modifier.fillMaxWidth()) {
-            for (i in 1..5) {
-                Button(
-                    onClick = { current = i; onValueChange(i.toString()) },
-                    selected = current == i,
-                    modifier = Modifier.weight(1f).numericButtonDefaults(),
+    val severityAlreadyStoredText = stringResource(Res.string.trait_error_disease_severity)
+    val rustCodes by produceState(initialValue = fallbackRustCodes) {
+        this.value = loadRustCodes()
+    }
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.Start,
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        rustCodes.chunked(6).forEach { rowCodes ->
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.Start)
                 ) {
-                    Text(i.toString())
+                    rowCodes.forEach { code ->
+                        Button(
+                            onClick = {
+                                if (value.contains(Regex("\\d")) &&
+                                    code.any { it.isDigit() } &&
+                                    !value.contains("/")
+                                ) {
+                                    onValidationError(severityAlreadyStoredText)
+                                } else {
+                                    appendDiseaseRatingValue(value, code)?.let(onValueChange)
+                                }
+                            },
+                            selected = false,
+                            modifier = Modifier
+                                .width(rustNumericButtonWidth)
+                                .height(rustButtonHeight),
+                            contentPadding = rustButtonContentPadding,
+                        ) {
+                            Text(
+                                text = code,
+                                color = Color.Black,
+                                style = rustNumericTextStyle,
+                                maxLines = 1,
+                                softWrap = false,
+                                overflow = TextOverflow.Clip
+                            )
+                        }
+                    }
                 }
-                Spacer(Modifier.size(8.dp))
+            }
+        }
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.Start)
+            ) {
+                listOf("R", "M", "S", "/").forEach { code ->
+                    Button(
+                        onClick = {
+                            appendDiseaseRatingValue(value, code)?.let(onValueChange)
+                        },
+                        selected = false,
+                        modifier = Modifier
+                            .width(rustLetterButtonWidth)
+                            .height(rustButtonHeight),
+                        contentPadding = rustButtonContentPadding,
+                    ) {
+                        Text(
+                            text = code,
+                            color = Color.Black,
+                            style = rustLetterTextStyle,
+                            maxLines = 1,
+                            softWrap = false,
+                            overflow = TextOverflow.Clip
+                        )
+                    }
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/theme/Theme.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/theme/Theme.kt
@@ -87,6 +87,7 @@ fun Button(
     modifier: Modifier = Modifier,
     shape: androidx.compose.foundation.shape.CornerBasedShape = MaterialTheme.shapes.small,
     selectedColor: Color = MaterialTheme.colorScheme.primary,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     content: @Composable RowScope.() -> Unit
 ) {
     val borderModifier = if (!selected) Modifier.border(1.dp, Color.Black, shape) else Modifier
@@ -95,6 +96,7 @@ fun Button(
         colors = traitButtonColors(selected, selectedColor),
         modifier = modifier.then(borderModifier),
         shape = shape,
+        contentPadding = contentPadding,
         content = content
     )
 }

--- a/shared/src/iosMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTraitPlatform.ios.kt
+++ b/shared/src/iosMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTraitPlatform.ios.kt
@@ -1,0 +1,185 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.fieldbook.shared.screens.collect.traits
+
+import platform.AVFAudio.AVAudioPlayer
+import platform.AVFAudio.AVAudioRecorder
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryPlayAndRecord
+import platform.AVFAudio.AVEncoderAudioQualityKey
+import platform.AVFAudio.AVFormatIDKey
+import platform.AVFAudio.AVNumberOfChannelsKey
+import platform.AVFAudio.AVSampleRateKey
+import platform.AVFAudio.prepareToPlay
+import platform.AVFAudio.setActive
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSFileModificationDate
+import platform.Foundation.NSNumber
+import platform.Foundation.NSURL
+import platform.Foundation.NSURL.Companion.fileURLWithPath
+import platform.darwin.DISPATCH_TIME_NOW
+import platform.darwin.NSEC_PER_SEC
+import platform.darwin.dispatch_after
+import platform.darwin.dispatch_get_main_queue
+import platform.darwin.dispatch_time
+import kotlin.math.ceil
+import kotlin.math.ln
+import kotlin.math.pow
+
+actual class PlatformAudioController {
+    private var recorder: AVAudioRecorder? = null
+    private var player: AVAudioPlayer? = null
+    private var playbackToken: Long = 0L
+
+    actual fun startRecording(outputUri: String): Boolean {
+        return try {
+            stopPlayback()
+            stopRecording()
+
+            val outputUrl = outputUri.toPlatformFileUrl() ?: return false
+            configureAudioSession() ?: return false
+
+            val settings = mapOf<Any?, Any?>(
+                AVFormatIDKey to 1633772320u,
+                AVSampleRateKey to 44100.0,
+                AVNumberOfChannelsKey to 1,
+                AVEncoderAudioQualityKey to 2
+            )
+
+            val audioRecorder = AVAudioRecorder(outputUrl, settings, null) ?: return false
+
+            recorder = audioRecorder
+            audioRecorder.prepareToRecord()
+            audioRecorder.record()
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    actual fun stopRecording() {
+        recorder?.stop()
+        recorder = null
+    }
+
+    actual fun startPlayback(inputUri: String, onPlaybackCompleted: () -> Unit): Boolean {
+        return try {
+            stopPlayback()
+            val inputUrl = inputUri.toPlatformFileUrl() ?: return false
+            val audioPlayer = AVAudioPlayer(inputUrl, null) ?: return false
+
+            player = audioPlayer
+            playbackToken += 1
+            val token = playbackToken
+            audioPlayer.prepareToPlay()
+            if (!audioPlayer.play()) {
+                stopPlayback()
+                return false
+            }
+
+            val delayNanos = (audioPlayer.duration * NSEC_PER_SEC.toDouble()).toLong()
+            dispatch_after(
+                dispatch_time(DISPATCH_TIME_NOW, delayNanos),
+                dispatch_get_main_queue()
+            ) {
+                if (playbackToken == token) {
+                    stopPlayback()
+                    onPlaybackCompleted()
+                }
+            }
+            true
+        } catch (_: Throwable) {
+            stopPlayback()
+            false
+        }
+    }
+
+    actual fun stopPlayback() {
+        playbackToken += 1
+        player?.stop()
+        player = null
+    }
+
+    actual fun dispose() {
+        stopRecording()
+        stopPlayback()
+    }
+
+    private fun configureAudioSession(): AVAudioSession? {
+        return try {
+            val session = AVAudioSession.sharedInstance()
+            session.setCategory(AVAudioSessionCategoryPlayAndRecord, error = null)
+            session.setActive(true, error = null)
+            session
+        } catch (_: Throwable) {
+            null
+        }
+    }
+}
+
+actual fun inspectAudioTraitFile(uri: String): AudioTraitMetadata? {
+    return try {
+        val fileUrl = uri.toPlatformFileUrl() ?: return null
+        val path = fileUrl.path?.toString() ?: return null
+        val attrs = NSFileManager.defaultManager.attributesOfItemAtPath(path, error = null)
+            ?: return null
+        val modifiedDate = attrs[NSFileModificationDate] as? NSDate
+        val sizeBytes = (attrs["NSFileSize"] as? NSNumber)?.longLongValue ?: 0L
+        val player = AVAudioPlayer(fileUrl, null)
+
+        AudioTraitMetadata(
+            timestamp = modifiedDate?.let(::formatDate) ?: "",
+            duration = formatDurationSeconds(player?.duration ?: 0.0),
+            fileSize = formatFileSize(sizeBytes)
+        )
+    } catch (_: Throwable) {
+        null
+    }
+}
+
+private fun String.toPlatformFileUrl(): NSURL? {
+    return when {
+        startsWith("file://") -> NSURL.URLWithString(this)
+        startsWith("/") -> fileURLWithPath(this)
+        else -> NSURL.URLWithString(this)
+    }
+}
+
+private fun formatDate(date: NSDate): String {
+    val formatter = NSDateFormatter()
+    formatter.dateFormat = "MMM d, yyyy | h:mm a"
+    return formatter.stringFromDate(date)
+}
+
+private fun formatDurationSeconds(durationSeconds: Double): String {
+    val totalSeconds = ceil(durationSeconds).toLong()
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    val minutePrefix = if (minutes < 10) "0" else ""
+    val secondPrefix = if (seconds < 10) "0" else ""
+    return "$minutePrefix$minutes:$secondPrefix$seconds"
+}
+
+private fun formatFileSize(bytes: Long): String {
+    if (bytes < 1024L) return "$bytes B"
+    val exponent = (ln(bytes.toDouble()) / ln(1024.0)).toInt()
+    val prefix = "KMGTPE"[exponent - 1].toString()
+    val value = bytes / 1024.0.pow(exponent.toDouble())
+    return "${value.toFixed(2)} ${prefix}B"
+}
+
+private fun Double.toFixed(decimals: Int): String {
+    val multiplier = 10.0.pow(decimals.toDouble())
+    val rounded = kotlin.math.round(this * multiplier) / multiplier
+    val text = rounded.toString()
+    val dotIndex = text.indexOf('.')
+    if (dotIndex == -1) return "$text.${"0".repeat(decimals)}"
+
+    val fractionalLength = text.length - dotIndex - 1
+    return if (fractionalLength >= decimals) {
+        text
+    } else {
+        text + "0".repeat(decimals - fractionalLength)
+    }
+}


### PR DESCRIPTION
### Description

This PR brings the KMP trait audio and rust score collect behavior from `IBP-7142-kmp-traits` into the current `IBP-7142-kmp` workstream.

It adds platform-specific `AudioTrait` support for Android and iOS, wires the trait into the shared collect flow, and enables interaction locking while audio recording or playback is active. It also restores the rust score (`DiseaseRatingTrait`) collect experience, including the native-style severity input layout and the fallback trait-format wiring needed so it works correctly across platforms, including iOS.

As part of the integration, this PR also includes the minimal shared UI support required by rust score (`contentPadding` support in the shared button wrapper) and resolves collect-side wiring inconsistencies so the shared Android and iOS builds both succeed.

### Change Type

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [x] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

```release-note
Added KMP support for trait audio collection and restored rust score collection behavior across Android and iOS.