### PR TITLE
Ibp 7142 kmp collect

### DIFF
--- a/shared/docs/kmp-migration-checklist.md
+++ b/shared/docs/kmp-migration-checklist.md
@@ -83,12 +83,12 @@
 | **Collect actions**              |                    |                    |
 | Search                           |                    |                    |
 | Resources                        |                    |                    |
-| Summary                          |                    |                    |
-| Lock                             |                    |                    |
-| Freeze                           |                    |                    |
-| Scan                             |                    |                    |
-| Set NA                           |                    |                    |
-| Delete                           |                    |                    |
+| Summary                          | :white_check_mark: | :white_check_mark: |
+| Lock                             | :white_check_mark: | :white_check_mark: |
+| Freeze                           | :white_check_mark: | :white_check_mark: |
+| Scan                             | :white_check_mark: | :white_check_mark: |
+| Set NA                           | :white_check_mark: | :white_check_mark: |
+| Delete                           | :white_check_mark: | :white_check_mark: |
 | Data grid                        | :white_check_mark: | :white_check_mark: |
 |                                  |                    |                    |
 | **Export**                       |                    |                    |
@@ -117,11 +117,11 @@
 | **Settings/Appearance**          |                    |                    |
 | Theme                            |                    |                    |
 | Language                         |                    |                    |
-| Toolbar actions                  |                    |                    |
-| Number of infobars               |                    |                    |
-| Hide infobar prefix              |                    |                    |
-| Entries progress bar             |                    |                    |
-| Traits progress bar              |                    |                    |
+| Toolbar actions                  | :white_check_mark: | :white_check_mark: |
+| Number of infobars               | :white_check_mark: | :white_check_mark: |
+| Hide infobar prefix              | :white_check_mark: | :white_check_mark: |
+| Entries progress bar             | :white_check_mark: | :white_check_mark: |
+| Traits progress bar              | :white_check_mark: | :white_check_mark: |
 |                                  |                    |                    |
 | **Settings/Appearance/Theme**    |                    |                    |
 | Theme                            |                    |                    |
@@ -216,7 +216,7 @@
 | ...                              |                    |                    |
 |                                  |                    |                    |
 | **Traits**                       |                    |                    |
-| Import from BrAPI                | :white_check_mark: |                    |
+| Import from BrAPI                | :white_check_mark: | :white_check_mark: |
 |                                  |                    |                    |
 | ...                              |                    |                    |
 |                                  |                    |                    |
@@ -247,12 +247,12 @@
 | OIDC Scope                       |                    |                    |
 |                                  |                    |                    |
 | **Settings/BrAPI/Advanced**      |                    |                    |
-| BrAPI version / V1               | :white_check_mark: |                    |
-| BrAPI version / V2               | :white_check_mark: |                    |
-| Page size                        | :white_check_mark: |                    |
+| BrAPI version / V1               | :white_check_mark: | :white_check_mark: |
+| BrAPI version / V2               | :white_check_mark: | :white_check_mark: |
+| Page size                        | :white_check_mark: | :white_check_mark: |
 | Chunk size                       |                    |                    |
 | Server timeout                   |                    |                    |
 | Cache invalidation               | :white_check_mark: |                    |
 |                                  |                    |                    |
 | **Settings/BrAPI/Preferences**   |                    |                    |
-| Value vs Label display           |                    |                    |
+| Value vs Label display           | :white_check_mark: | :white_check_mark: |

--- a/shared/docs/kmp-migration-checklist.md
+++ b/shared/docs/kmp-migration-checklist.md
@@ -237,7 +237,7 @@
 | Authorize                        | :white_check_mark: | :white_check_mark: |
 | Display name                     |                    |                    |
 | Auto-configure                   |                    |                    |
-| Logout                           | :white_check_mark: |                    |
+| Logout                           | :white_check_mark: | :white_check_mark: |
 |                                  |                    |                    |
 | **Settings/BrAPI/Authorization** |                    |                    |
 | OIDC Flow / Implicit Grant       | :white_check_mark: |                    |
@@ -252,7 +252,7 @@
 | Page size                        | :white_check_mark: | :white_check_mark: |
 | Chunk size                       |                    |                    |
 | Server timeout                   |                    |                    |
-| Cache invalidation               | :white_check_mark: |                    |
+| Cache invalidation               | :white_check_mark: | :white_check_mark: |
 |                                  |                    |                    |
 | **Settings/BrAPI/Preferences**   |                    |                    |
 | Value vs Label display           | :white_check_mark: | :white_check_mark: |

--- a/shared/src/androidMain/kotlin/com/fieldbook/shared/preferences/StringSetPreference.android.kt
+++ b/shared/src/androidMain/kotlin/com/fieldbook/shared/preferences/StringSetPreference.android.kt
@@ -1,0 +1,30 @@
+package com.fieldbook.shared.preferences
+
+import androidx.preference.PreferenceManager
+import com.fieldbook.shared.AndroidAppContextHolder
+import com.russhwolf.settings.Settings
+
+actual fun loadStringSetPreference(
+    settings: Settings,
+    key: String,
+    legacySeparators: CharArray,
+): Set<String>? {
+    val preferences = PreferenceManager.getDefaultSharedPreferences(AndroidAppContextHolder.context)
+    if (preferences.contains(key)) {
+        return preferences.getStringSet(key, emptySet())?.toSet() ?: emptySet()
+    }
+
+    return decodeStoredStringSetPreference(
+        serialized = settings.getStringOrNull(key),
+        legacySeparators = legacySeparators
+    )
+}
+
+actual fun persistStringSetPreference(
+    settings: Settings,
+    key: String,
+    values: Set<String>,
+) {
+    val preferences = PreferenceManager.getDefaultSharedPreferences(AndroidAppContextHolder.context)
+    preferences.edit().putStringSet(key, values).apply()
+}

--- a/shared/src/androidMain/kotlin/com/fieldbook/shared/preferences/ToolbarCustomizationPreference.android.kt
+++ b/shared/src/androidMain/kotlin/com/fieldbook/shared/preferences/ToolbarCustomizationPreference.android.kt
@@ -1,0 +1,29 @@
+package com.fieldbook.shared.preferences
+
+import androidx.preference.PreferenceManager
+import com.fieldbook.shared.AndroidAppContextHolder
+import com.russhwolf.settings.Settings
+
+actual fun loadToolbarCustomizationPreference(
+    settings: Settings,
+    key: String,
+    defaultOptions: Set<String>,
+): Set<String> {
+    return loadStringSetPreference(
+        settings = settings,
+        key = key,
+        legacySeparators = charArrayOf(',', '\n')
+    ) ?: defaultOptions
+}
+
+actual fun persistToolbarCustomizationPreference(
+    settings: Settings,
+    key: String,
+    values: Set<String>,
+) {
+    persistStringSetPreference(
+        settings = settings,
+        key = key,
+        values = values
+    )
+}

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/database/repository/ObservationUnitPropertyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/database/repository/ObservationUnitPropertyRepository.kt
@@ -125,4 +125,46 @@ class ObservationUnitPropertyRepository(
         return getSortedObservationUnitData(studyId)
     }
 
+    fun getAttributeValuesForUnit(
+        uniqueName: String,
+        unitId: String,
+        attributeLabels: List<String>
+    ): Map<String, String> {
+        if (uniqueName.isBlank() || unitId.isBlank() || attributeLabels.isEmpty()) return emptyMap()
+
+        val selectStatement = attributeLabels.joinToString(", ") { label ->
+            sqlIdentifier(label)
+        }
+
+        val query = """
+            SELECT $selectStatement
+            FROM $sObservationUnitPropertyViewName
+            WHERE ${sqlIdentifier(uniqueName)} = ?
+            LIMIT 1
+        """.trimIndent()
+
+        val result = driver.executeQuery(
+            identifier = null,
+            sql = query,
+            mapper = { cursor ->
+                if (!cursor.next().value) {
+                    return@executeQuery QueryResult.Value(emptyMap())
+                }
+
+                val values = attributeLabels.mapIndexed { index, label ->
+                    label to (cursor.getString(index) ?: "")
+                }.toMap()
+
+                QueryResult.Value(values)
+            },
+            parameters = 1
+        ) {
+            bindString(0, unitId)
+        }
+
+        return result.value
+    }
+
+    private fun sqlIdentifier(value: String): String = "\"${value.replace("\"", "\"\"")}\""
+
 }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/preferences/GeneralKeys.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/preferences/GeneralKeys.kt
@@ -129,6 +129,7 @@ enum class GeneralKeys(val key: String) {
 
     // summary filter
     SUMMARY_FILTER_ATTRIBUTES("com.fieldbook.tracker.summary.SUMMARY_FILTER_ATTRIBUTES"),
+    SUMMARY_FILTER_TRAITS("com.fieldbook.tracker.summary.SUMMARY_FILTER_TRAITS"),
 
     // Other
 

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/preferences/StringSetPreference.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/preferences/StringSetPreference.kt
@@ -1,0 +1,87 @@
+package com.fieldbook.shared.preferences
+
+import com.russhwolf.settings.Settings
+
+private const val EmptySetSentinel = "__FIELDBOOK_EMPTY_SET__"
+private const val Delimiter = '\u001F'
+private const val Escape = '\\'
+
+expect fun loadStringSetPreference(
+    settings: Settings,
+    key: String,
+    legacySeparators: CharArray = charArrayOf(),
+): Set<String>?
+
+expect fun persistStringSetPreference(
+    settings: Settings,
+    key: String,
+    values: Set<String>,
+)
+
+internal fun decodeStoredStringSetPreference(
+    serialized: String?,
+    legacySeparators: CharArray = charArrayOf(),
+): Set<String>? {
+    if (serialized == null) return null
+    if (serialized.isEmpty() || serialized == EmptySetSentinel) return emptySet()
+
+    val useLegacySeparators = serialized.indexOf(Delimiter) == -1 &&
+        legacySeparators.any { separator -> separator in serialized }
+
+    return if (useLegacySeparators) {
+        serialized.split(*legacySeparators)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+    } else {
+        decodeEscapedStringSet(serialized)
+    }
+}
+
+internal fun encodeStoredStringSetPreference(values: Set<String>): String {
+    if (values.isEmpty()) return EmptySetSentinel
+
+    return values.joinToString(Delimiter.toString()) { value ->
+        buildString {
+            value.forEach { character ->
+                if (character == Escape || character == Delimiter) {
+                    append(Escape)
+                }
+                append(character)
+            }
+        }
+    }
+}
+
+private fun decodeEscapedStringSet(serialized: String): Set<String> {
+    val items = mutableListOf<String>()
+    val currentValue = StringBuilder()
+    var isEscaped = false
+
+    serialized.forEach { character ->
+        when {
+            isEscaped -> {
+                currentValue.append(character)
+                isEscaped = false
+            }
+
+            character == Escape -> isEscaped = true
+            character == Delimiter -> {
+                items += currentValue.toString()
+                currentValue.clear()
+            }
+
+            else -> currentValue.append(character)
+        }
+    }
+
+    if (isEscaped) {
+        currentValue.append(Escape)
+    }
+
+    items += currentValue.toString()
+
+    return items
+        .filter { it.isNotEmpty() }
+        .toSet()
+}

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/preferences/ToolbarCustomizationPreference.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/preferences/ToolbarCustomizationPreference.kt
@@ -1,0 +1,15 @@
+package com.fieldbook.shared.preferences
+
+import com.russhwolf.settings.Settings
+
+expect fun loadToolbarCustomizationPreference(
+    settings: Settings,
+    key: String,
+    defaultOptions: Set<String>,
+): Set<String>
+
+expect fun persistToolbarCustomizationPreference(
+    settings: Settings,
+    key: String,
+    values: Set<String>,
+)

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/ScannerScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/ScannerScreen.kt
@@ -1,10 +1,24 @@
 package com.fieldbook.shared.screens
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.chevron_left
 import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
@@ -13,6 +27,7 @@ import com.kashif.cameraK.ui.CameraPreview
 import com.kashif.qrscannerplugin.rememberQRScannerPlugin
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun ScannerScreen(
@@ -37,17 +52,43 @@ fun ScannerScreen(
             }
     }
 
-    CameraPreview(
-        modifier = Modifier.fillMaxSize(),
-        cameraConfiguration = {
-            setCameraLens(CameraLens.BACK)
-            setFlashMode(FlashMode.OFF)
-            setImageFormat(ImageFormat.JPEG)
-            setDirectory(Directory.PICTURES)
-            addPlugin(qrScannerPlugin)
-        },
-        onCameraControllerReady = {
-            qrScannerPlugin.startScanning()
+    Box(modifier = Modifier.fillMaxSize()) {
+        CameraPreview(
+            modifier = Modifier.fillMaxSize(),
+            cameraConfiguration = {
+                setCameraLens(CameraLens.BACK)
+                setFlashMode(FlashMode.OFF)
+                setImageFormat(ImageFormat.JPEG)
+                setDirectory(Directory.PICTURES)
+                addPlugin(qrScannerPlugin)
+            },
+            onCameraControllerReady = {
+                qrScannerPlugin.startScanning()
+            }
+        )
+
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .statusBarsPadding()
+                .padding(start = 12.dp, top = 8.dp)
+                .size(64.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
+                    shape = CircleShape
+                )
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    shape = CircleShape
+                )
+        ) {
+            Icon(
+                painter = painterResource(Res.drawable.chevron_left),
+                contentDescription = "Back to collector",
+                modifier = Modifier.size(28.dp)
+            )
         }
-    )
+    }
 }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectInput.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectInput.kt
@@ -1,6 +1,7 @@
 package com.fieldbook.shared.screens.collect
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -76,6 +77,7 @@ fun CollectInput(
     }
     val usesLazyVerticalInput =
         formatEnum == Formats.CATEGORICAL || formatEnum == Formats.MULTI_CATEGORICAL
+    val isCurrentObservationLocked = controller.isCurrentObservationLocked()
     val labelValPref = remember { Settings() }
         .getString(PreferenceKeys.LABELVAL_CUSTOMIZE, "value")
     val showLabel = labelValPref == "label"
@@ -157,56 +159,85 @@ fun CollectInput(
         Spacer(Modifier.height(16.dp))
 
         if (formatEnum == Formats.TEXT) {
-            key(currentPlotId, currentTraitId) {
-                EditableValueText(
-                    value = value,
-                    onValueChange = {
-                        controller.updateCurrentTraitValue(it)
-                        isEdited = true
-                    },
-                    modifier = Modifier.fillMaxWidth().padding(8.dp),
-                    isEdited = isEdited,
-                    color = fontColor,
-                    defaultValue = trait?.defaultValue,
-                    closeKeyboardOnOpen = trait?.closeKeyboardOnOpen == true,
-                )
+            Box(modifier = Modifier.fillMaxWidth()) {
+                key(currentPlotId, currentTraitId) {
+                    EditableValueText(
+                        value = value,
+                        onValueChange = {
+                            controller.updateCurrentTraitValue(it)
+                            isEdited = true
+                        },
+                        modifier = Modifier.fillMaxWidth().padding(8.dp),
+                        isEdited = isEdited,
+                        color = fontColor,
+                        defaultValue = trait?.defaultValue,
+                        closeKeyboardOnOpen = trait?.closeKeyboardOnOpen == true,
+                        enabled = !isCurrentObservationLocked,
+                    )
+                }
+                if (isCurrentObservationLocked) {
+                    LockedInputOverlay(
+                        modifier = Modifier.matchParentSize(),
+                        onClick = controller::showCurrentDataLockMessage
+                    )
+                }
             }
         } else if (formatEnum?.isCamera == true) {
-            TraitInputContainer(
-                usesLazyVerticalInput = false,
-                scrollable = false,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
             ) {
-                key(currentPlotId, currentTraitId) {
-                    TraitInputHost(
-                        controller = controller,
-                        trait = trait,
-                        values = values,
-                        onEdited = { isEdited = true },
-                        modifier = Modifier.fillMaxWidth(),
-                        onExpandPhotoTrait = onExpandPhotoTrait
+                TraitInputContainer(
+                    usesLazyVerticalInput = false,
+                    scrollable = false,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    key(currentPlotId, currentTraitId) {
+                        TraitInputHost(
+                            controller = controller,
+                            trait = trait,
+                            values = values,
+                            onEdited = { isEdited = true },
+                            modifier = Modifier.fillMaxWidth(),
+                            onExpandPhotoTrait = onExpandPhotoTrait
+                        )
+                    }
+                }
+                if (isCurrentObservationLocked) {
+                    LockedInputOverlay(
+                        modifier = Modifier.matchParentSize(),
+                        onClick = controller::showCurrentDataLockMessage
                     )
                 }
             }
         } else if (formatEnum == Formats.AUDIO) {
-            TraitInputContainer(
-                usesLazyVerticalInput = false,
-                scrollable = false,
-                centerContent = false,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
             ) {
-                key(currentPlotId, currentTraitId) {
-                    TraitInputHost(
-                        controller = controller,
-                        trait = trait,
-                        values = values,
-                        onEdited = { isEdited = true },
-                        modifier = Modifier.fillMaxWidth(),
-                        onExpandPhotoTrait = onExpandPhotoTrait
+                TraitInputContainer(
+                    usesLazyVerticalInput = false,
+                    scrollable = false,
+                    centerContent = false,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    key(currentPlotId, currentTraitId) {
+                        TraitInputHost(
+                            controller = controller,
+                            trait = trait,
+                            values = values,
+                            onEdited = { isEdited = true },
+                            modifier = Modifier.fillMaxWidth(),
+                            onExpandPhotoTrait = onExpandPhotoTrait
+                        )
+                    }
+                }
+                if (isCurrentObservationLocked) {
+                    LockedInputOverlay(
+                        modifier = Modifier.matchParentSize(),
+                        onClick = controller::showCurrentDataLockMessage
                     )
                 }
             }
@@ -226,20 +257,30 @@ fun CollectInput(
                     .padding(8.dp)
                     .background(androidx.compose.material3.MaterialTheme.colorScheme.primary)
             )
-            TraitInputContainer(
-                usesLazyVerticalInput = usesLazyVerticalInput,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
             ) {
-                key(currentPlotId, currentTraitId) {
-                    TraitInputHost(
-                        controller = controller,
-                        trait = trait,
-                        values = values,
-                        onEdited = { isEdited = true },
-                        modifier = Modifier.fillMaxWidth(),
-                        onExpandPhotoTrait = onExpandPhotoTrait
+                TraitInputContainer(
+                    usesLazyVerticalInput = usesLazyVerticalInput,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    key(currentPlotId, currentTraitId) {
+                        TraitInputHost(
+                            controller = controller,
+                            trait = trait,
+                            values = values,
+                            onEdited = { isEdited = true },
+                            modifier = Modifier.fillMaxWidth(),
+                            onExpandPhotoTrait = onExpandPhotoTrait
+                        )
+                    }
+                }
+                if (isCurrentObservationLocked) {
+                    LockedInputOverlay(
+                        modifier = Modifier.matchParentSize(),
+                        onClick = controller::showCurrentDataLockMessage
                     )
                 }
             }
@@ -454,6 +495,7 @@ fun EditableValueText(
     color: androidx.compose.ui.graphics.Color = AppColors.fb_color_text_dark.color,
     defaultValue: String? = null,
     closeKeyboardOnOpen: Boolean = false,
+    enabled: Boolean = true,
 ) {
     TextTrait(
         value = value,
@@ -463,6 +505,7 @@ fun EditableValueText(
         isEdited = isEdited,
         editedColor = color,
         closeKeyboardOnOpen = closeKeyboardOnOpen,
+        enabled = enabled,
     )
     Box(
         modifier = Modifier
@@ -470,6 +513,18 @@ fun EditableValueText(
             .height(18.dp)
             .padding(8.dp)
             .background(androidx.compose.material3.MaterialTheme.colorScheme.primary)
+    )
+}
+
+@Composable
+private fun LockedInputOverlay(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .background(androidx.compose.ui.graphics.Color.Transparent)
+            .clickable(onClick = onClick)
     )
 }
 

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectInput.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectInput.kt
@@ -497,23 +497,28 @@ fun EditableValueText(
     closeKeyboardOnOpen: Boolean = false,
     enabled: Boolean = true,
 ) {
-    TextTrait(
-        value = value,
-        onValueChange = onValueChange,
-        modifier = modifier,
-        defaultValue = defaultValue,
-        isEdited = isEdited,
-        editedColor = color,
-        closeKeyboardOnOpen = closeKeyboardOnOpen,
-        enabled = enabled,
-    )
-    Box(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
-            .height(18.dp)
-            .padding(8.dp)
-            .background(androidx.compose.material3.MaterialTheme.colorScheme.primary)
-    )
+    ) {
+        TextTrait(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier,
+            defaultValue = defaultValue,
+            isEdited = isEdited,
+            editedColor = color,
+            closeKeyboardOnOpen = closeKeyboardOnOpen,
+            enabled = enabled,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(18.dp)
+                .padding(8.dp)
+                .background(androidx.compose.material3.MaterialTheme.colorScheme.primary)
+        )
+    }
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectInput.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectInput.kt
@@ -2,23 +2,11 @@ package com.fieldbook.shared.screens.collect
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontStyle
@@ -26,18 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.fieldbook.shared.preferences.PreferenceKeys
-import com.fieldbook.shared.screens.collect.traits.BooleanTrait
-import com.fieldbook.shared.screens.collect.traits.CategoricalTrait
-import com.fieldbook.shared.screens.collect.traits.CounterTrait
-import com.fieldbook.shared.screens.collect.traits.DateTrait
-import com.fieldbook.shared.screens.collect.traits.DiseaseRatingTrait
-import com.fieldbook.shared.screens.collect.traits.AngleTrait
-import com.fieldbook.shared.screens.collect.traits.AudioTrait
-import com.fieldbook.shared.screens.collect.traits.LocationTrait
-import com.fieldbook.shared.screens.collect.traits.NumericTrait
-import com.fieldbook.shared.screens.collect.traits.PercentTrait
-import com.fieldbook.shared.screens.collect.traits.PhotoTrait
-import com.fieldbook.shared.screens.collect.traits.TextTrait
+import com.fieldbook.shared.screens.collect.traits.*
 import com.fieldbook.shared.theme.AppColors
 import com.fieldbook.shared.traits.Formats
 import com.fieldbook.shared.utilities.CategoryJsonUtil
@@ -82,70 +59,77 @@ fun CollectInput(
         .getString(PreferenceKeys.LABELVAL_CUSTOMIZE, "value")
     val showLabel = labelValPref == "label"
 
-    val displayValue = when (formatEnum) {
-        Formats.CATEGORICAL -> {
-            try {
-                val decoded = CategoryJsonUtil.decode(value)
-                if (decoded.isNotEmpty()) {
-                    if (showLabel) {
-                        decoded[0].label ?: decoded[0].value ?: value
+    val displayValue = when {
+        value == "NA" -> "NA"
+        else -> when (formatEnum) {
+            Formats.CATEGORICAL -> {
+                try {
+                    val decoded = CategoryJsonUtil.decode(value)
+                    if (decoded.isNotEmpty()) {
+                        if (showLabel) {
+                            decoded[0].label ?: decoded[0].value ?: value
+                        } else {
+                            decoded[0].value ?: decoded[0].label ?: value
+                        }
                     } else {
-                        decoded[0].value ?: decoded[0].label ?: value
+                        value
                     }
-                } else {
+                } catch (_: Throwable) {
+                    // If it's not valid JSON or decode fails, fall back to raw value
                     value
                 }
-            } catch (_: Throwable) {
-                // If it's not valid JSON or decode fails, fall back to raw value
-                value
             }
-        }
 
-        Formats.MULTI_CATEGORICAL -> {
-            try {
-                val decoded = CategoryJsonUtil.decode(value)
-                decoded.joinToString(":") {
-                    if (showLabel) it.label ?: it.value ?: "" else it.value ?: it.label ?: ""
+            Formats.MULTI_CATEGORICAL -> {
+                try {
+                    val decoded = CategoryJsonUtil.decode(value)
+                    decoded.joinToString(":") {
+                        if (showLabel) it.label ?: it.value ?: "" else it.value ?: it.label ?: ""
+                    }
+                } catch (_: Throwable) {
+                    value
                 }
-            } catch (_: Throwable) {
-                value
             }
-        }
 
-        Formats.DATE -> {
-            try {
-                dateFormatMonthDay(value)
-            } catch (_: Throwable) {
-                value
+            Formats.DATE -> {
+                try {
+                    dateFormatMonthDay(value)
+                } catch (_: Throwable) {
+                    value
+                }
             }
-        }
 
-        Formats.NUMERIC -> {
-            val shouldUseDefault = trait?.id?.let(controller::shouldUseDefaultValue) == true
-            if (value.isEmpty() && shouldUseDefault) trait?.defaultValue.orEmpty() else value
-        }
-        Formats.PERCENT -> {
-            val raw = if (value.isEmpty()) trait?.defaultValue.orEmpty() else value
-            when {
-                raw.isBlank() -> ""
-                raw == "NA" -> "NA"
-                raw.endsWith("%") -> raw
-                else -> "$raw%"
+            Formats.NUMERIC -> {
+                val shouldUseDefault = trait?.id?.let(controller::shouldUseDefaultValue) == true
+                if (value.isEmpty() && shouldUseDefault) trait?.defaultValue.orEmpty() else value
             }
-        }
-        Formats.BOOLEAN -> {
-            val shouldUseDefault = trait?.id?.let(controller::shouldUseDefaultValue) == true
-            val raw = if (value.isEmpty() && shouldUseDefault) trait?.defaultValue.orEmpty() else value
-            when {
-                raw.equals("true", ignoreCase = true) -> "TRUE"
-                raw.equals("false", ignoreCase = true) -> "FALSE"
-                else -> ""
+
+            Formats.PERCENT -> {
+                val raw = if (value.isEmpty()) trait?.defaultValue.orEmpty() else value
+                when {
+                    raw.isBlank() -> ""
+                    raw == "NA" -> "NA"
+                    raw.endsWith("%") -> raw
+                    else -> "$raw%"
+                }
             }
+
+            Formats.BOOLEAN -> {
+                val shouldUseDefault = trait?.id?.let(controller::shouldUseDefaultValue) == true
+                val raw = if (value.isEmpty() && shouldUseDefault) trait?.defaultValue.orEmpty() else value
+                when {
+                    raw.equals("true", ignoreCase = true) -> "TRUE"
+                    raw.equals("false", ignoreCase = true) -> "FALSE"
+                    else -> ""
+                }
+            }
+
+            Formats.COUNTER -> {
+                if (value.isEmpty()) "0" else value
+            }
+
+            else -> value
         }
-        Formats.COUNTER -> {
-            if (value.isEmpty()) "0" else value
-        }
-        else -> value
     }
 
     Column(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -35,15 +36,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.ic_field
 import com.fieldbook.shared.generated.resources.ic_lock_clock
+import com.fieldbook.shared.generated.resources.ic_tb_delete
 import com.fieldbook.shared.generated.resources.ic_tb_lock
 import com.fieldbook.shared.generated.resources.ic_transfer_error
 import com.fieldbook.shared.generated.resources.ic_tb_unlock
+import com.fieldbook.shared.generated.resources.act_collect_delete_value_button_content_description
 import com.fieldbook.shared.preferences.PreferenceKeys
 import com.fieldbook.shared.screens.collect.traits.PhotoTrait
 import com.fieldbook.shared.screens.collect.traits.PhotoTraitDisplayMode
@@ -51,6 +57,7 @@ import com.fieldbook.shared.screens.datagrid.DataGridScreen
 import com.fieldbook.shared.traits.Formats
 import com.russhwolf.settings.Settings
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * KMP version of CollectActivity main screen logic.
@@ -87,6 +94,7 @@ fun CollectScreen(
         Formats.entries.find { it.databaseName.equals(formatStr, ignoreCase = true) }
     }
     val isCurrentTraitCamera = currentFormat?.isCamera == true
+    val canDeleteCurrentValue = controller.hasCurrentTraitValue() && !controller.isCurrentObservationLocked()
 
     LaunchedEffect(controller.inputValidationMessage) {
         controller.inputValidationMessage?.let { message ->
@@ -181,6 +189,14 @@ fun CollectScreen(
                     actionIconContentColor = MaterialTheme.colorScheme.onPrimary
                 )
             )
+        },
+        bottomBar = {
+            CollectBottomBar(
+                canSetNa = !controller.isCurrentObservationLocked(),
+                canDeleteCurrentValue = canDeleteCurrentValue,
+                onSetNa = { controller.updateCurrentTraitValue("NA") },
+                onDelete = controller::clearCurrentTraitValue
+            )
         }
     ) { innerPadding ->
         Surface(
@@ -222,6 +238,78 @@ fun CollectScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun CollectBottomBar(
+    canSetNa: Boolean,
+    canDeleteCurrentValue: Boolean,
+    onSetNa: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.primary
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "NA",
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.alpha(0f)
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable(enabled = canSetNa, onClick = onSetNa),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "NA",
+                    color = if (canSetNa) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else {
+                        MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f)
+                    },
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center
+                )
+            }
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                IconButton(
+                    onClick = onDelete,
+                    enabled = canDeleteCurrentValue,
+                ) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_tb_delete),
+                        contentDescription = stringResource(Res.string.act_collect_delete_value_button_content_description),
+                        tint = if (canDeleteCurrentValue) {
+                            MaterialTheme.colorScheme.onPrimary
+                        } else {
+                            MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f)
+                        }
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.weight(1f))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
@@ -5,14 +5,19 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -25,6 +30,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -42,16 +48,32 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.act_collect_barcode_button_content_description
 import com.fieldbook.shared.generated.resources.ic_field
 import com.fieldbook.shared.generated.resources.ic_lock_clock
 import com.fieldbook.shared.generated.resources.ic_tb_barcode
 import com.fieldbook.shared.generated.resources.ic_tb_delete
+import com.fieldbook.shared.generated.resources.ic_tb_details
 import com.fieldbook.shared.generated.resources.ic_tb_lock
 import com.fieldbook.shared.generated.resources.ic_transfer_error
 import com.fieldbook.shared.generated.resources.ic_tb_unlock
 import com.fieldbook.shared.generated.resources.act_collect_delete_value_button_content_description
+import com.fieldbook.shared.generated.resources.fragment_summary_toolbar_title
+import com.fieldbook.shared.generated.resources.fragment_summary_filter_title
+import com.fieldbook.shared.generated.resources.fragment_summary_next_button_text
+import com.fieldbook.shared.generated.resources.fragment_summary_prev_button_text
+import com.fieldbook.shared.generated.resources.dialog_fragment_summary_neutral_button
+import com.fieldbook.shared.generated.resources.chevron_left
+import com.fieldbook.shared.generated.resources.chevron_right
+import com.fieldbook.shared.generated.resources.menu_fragment_summary_filter_title
+import com.fieldbook.shared.generated.resources.pencil
+import com.fieldbook.shared.generated.resources.preferences_appearance_toolbar_customize_summary
+import com.fieldbook.shared.database.repository.ObservationUnitAttributeRepository
+import com.fieldbook.shared.database.repository.ObservationUnitPropertyRepository
+import com.fieldbook.shared.preferences.GeneralKeys
 import com.fieldbook.shared.preferences.PreferenceKeys
 import com.fieldbook.shared.screens.ScannerScreen
 import com.fieldbook.shared.screens.collect.traits.PhotoTrait
@@ -59,6 +81,7 @@ import com.fieldbook.shared.screens.collect.traits.PhotoTraitDisplayMode
 import com.fieldbook.shared.screens.datagrid.DataGridScreen
 import com.fieldbook.shared.traits.Formats
 import com.fieldbook.shared.traits.Scannable
+import com.fieldbook.shared.utilities.CategoryJsonUtil
 import com.russhwolf.settings.Settings
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -76,6 +99,7 @@ fun CollectScreen(
 ) {
     var isCameraFullscreen by remember { mutableStateOf(false) }
     var isBarcodeScannerFullscreen by remember { mutableStateOf(false) }
+    var showSummaryDialog by remember { mutableStateOf(false) }
     var showDataGrid by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
     val settings = remember { Settings() }
@@ -100,6 +124,57 @@ fun CollectScreen(
     }
     val isCurrentTraitCamera = currentFormat?.isCamera == true
     val canDeleteCurrentValue = controller.hasCurrentTraitValue() && !controller.isCurrentObservationLocked()
+    var summaryFilter by remember(controller.studyId) {
+        mutableStateOf(loadCollectSummaryFilter(settings, controller.studyId))
+    }
+    val observationUnitPropertyRepository = remember { ObservationUnitPropertyRepository() }
+    val summaryAttributeLabels = remember(controller.studyId) {
+        ObservationUnitAttributeRepository().getAllNames(controller.studyId.toLong())
+    }
+    val summaryAttributeValues = remember(
+        controller.currentUnitIndex,
+        controller.units,
+        summaryAttributeLabels,
+        controller.uniqueId
+    ) {
+        val unit = controller.units.getOrNull(controller.currentUnitIndex)
+        if (unit == null) {
+            emptyMap()
+        } else {
+            observationUnitPropertyRepository.getAttributeValuesForUnit(
+                uniqueName = controller.uniqueId,
+                unitId = unit.observation_unit_db_id,
+                attributeLabels = summaryAttributeLabels
+            )
+        }
+    }
+    val summaryDefinitions = remember(
+        summaryAttributeLabels,
+        controller.currentUnitIndex,
+        controller.units,
+        controller.traits
+    ) {
+        buildCollectSummaryDefinitions(
+            attributeLabels = summaryAttributeLabels,
+            controller = controller
+        )
+    }
+    val summaryItems = remember(
+        summaryAttributeLabels,
+        controller.currentUnitIndex,
+        controller.units,
+        controller.traits,
+        controller.traitValues,
+        summaryFilter
+    ) {
+        buildCollectSummaryItems(
+            controller = controller,
+            attributeLabels = summaryAttributeLabels,
+            attributeValues = summaryAttributeValues,
+            showCategoryLabels = settings.getString(PreferenceKeys.LABELVAL_CUSTOMIZE, "value") != "value",
+            filter = summaryFilter
+        )
+    }
 
     LaunchedEffect(controller.inputValidationMessage) {
         controller.inputValidationMessage?.let { message ->
@@ -193,6 +268,15 @@ fun CollectScreen(
                         }
                     }
                     IconButton(
+                        onClick = { showSummaryDialog = true },
+                        enabled = !controller.collectInteractionLocked
+                    ) {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_tb_details),
+                            contentDescription = stringResource(Res.string.preferences_appearance_toolbar_customize_summary)
+                        )
+                    }
+                    IconButton(
                         onClick = { controller.cycleDataLockState() }
                     ) {
                         val lockIcon = when (controller.dataLockState) {
@@ -266,6 +350,469 @@ fun CollectScreen(
             }
         }
     }
+
+    if (showSummaryDialog) {
+        CollectSummaryDialog(
+            title = stringResource(Res.string.fragment_summary_toolbar_title),
+            items = summaryItems,
+            canNavigatePrevious = controller.units.isNotEmpty(),
+            canNavigateNext = controller.units.isNotEmpty(),
+            onFilterUpdated = { filter ->
+                summaryFilter = filter
+                persistCollectSummaryFilter(settings, controller.studyId, filter)
+            },
+            filterOptions = summaryDefinitions,
+            initialFilter = summaryFilter,
+            onTraitSelected = { traitId ->
+                val traitIndex = controller.traits.indexOfFirst { it.id == traitId }
+                if (traitIndex >= 0) {
+                    controller.updateCurrentTraitIndex(traitIndex)
+                }
+                showSummaryDialog = false
+            },
+            onPrevious = { controller.goToPreviousUnit() },
+            onNext = { controller.goToNextUnit() },
+            onDismiss = { showSummaryDialog = false }
+        )
+    }
+}
+
+private data class CollectSummaryDefinition(
+    val label: String,
+    val traitId: Long? = null,
+)
+
+private data class CollectSummaryItem(
+    val label: String,
+    val value: String,
+    val traitId: Long? = null,
+)
+
+private data class CollectSummaryFilter(
+    val attributeLabels: Set<String>? = null,
+    val traitIds: Set<Long>? = null,
+)
+
+private fun buildCollectSummaryDefinitions(
+    attributeLabels: List<String>,
+    controller: CollectScreenController,
+): List<CollectSummaryDefinition> {
+    if (controller.units.isEmpty()) return emptyList()
+
+    val traitDefinitions = controller.traits.mapNotNull { trait ->
+        val traitId = trait.id ?: return@mapNotNull null
+        CollectSummaryDefinition(label = trait.name, traitId = traitId)
+    }.sortedBy { it.label }
+
+    val attributeDefinitions = attributeLabels
+        .map { CollectSummaryDefinition(label = it) }
+        .sortedBy { it.label }
+
+    return attributeDefinitions + traitDefinitions
+}
+
+private fun buildCollectSummaryItems(
+    controller: CollectScreenController,
+    attributeLabels: List<String>,
+    attributeValues: Map<String, String>,
+    showCategoryLabels: Boolean,
+    filter: CollectSummaryFilter,
+): List<CollectSummaryItem> {
+    if (controller.units.getOrNull(controller.currentUnitIndex) == null) return emptyList()
+
+    val visibleAttributeLabels = filter.attributeLabels
+
+    val attributeItems = attributeLabels
+        .map { label ->
+            CollectSummaryItem(
+                label = label,
+                value = resolveSummaryAttributeValue(controller, label, attributeValues).ifBlank { "" }
+            )
+        }
+        .filter { visibleAttributeLabels == null || it.label in visibleAttributeLabels }
+        .sortedBy { it.label }
+
+    val visibleTraitIds = filter.traitIds
+
+    val traitItems = controller.traits.mapNotNull { trait ->
+        val traitId = trait.id ?: return@mapNotNull null
+        if (visibleTraitIds != null && traitId !in visibleTraitIds) return@mapNotNull null
+        val rawValue = controller.traitValues[traitId]?.joinToString("\n").orEmpty()
+
+        val displayValue = when (trait.format?.lowercase()) {
+            Formats.CATEGORICAL.databaseName,
+            Formats.MULTI_CATEGORICAL.databaseName -> {
+                try {
+                    CategoryJsonUtil.flattenMultiCategoryValue(
+                        CategoryJsonUtil.decode(rawValue),
+                        showLabel = showCategoryLabels
+                    ).ifBlank { rawValue }
+                } catch (_: Exception) {
+                    rawValue
+                }
+            }
+
+            else -> rawValue
+        }
+
+        CollectSummaryItem(
+            label = trait.name,
+            value = displayValue.ifBlank { "-" },
+            traitId = traitId
+        )
+    }.sortedBy { it.label }
+
+    return attributeItems + traitItems
+}
+
+private fun resolveSummaryAttributeValue(
+    controller: CollectScreenController,
+    label: String,
+    attributeValues: Map<String, String>,
+): String {
+    attributeValues[label]?.let { return it }
+
+    return when (label) {
+        controller.uniqueId -> controller.cRange.uniqueId
+        controller.primaryId -> controller.cRange.primaryId
+        controller.secondaryId -> controller.cRange.secondaryId
+        else -> ""
+    }
+}
+
+@Composable
+private fun CollectSummaryDialog(
+    title: String,
+    items: List<CollectSummaryItem>,
+    filterOptions: List<CollectSummaryDefinition>,
+    initialFilter: CollectSummaryFilter,
+    canNavigatePrevious: Boolean,
+    canNavigateNext: Boolean,
+    onFilterUpdated: (CollectSummaryFilter) -> Unit,
+    onTraitSelected: (Long) -> Unit,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var showFilterDialog by remember(initialFilter, filterOptions) { mutableStateOf(false) }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            shape = RoundedCornerShape(18.dp),
+            tonalElevation = 6.dp,
+            shadowElevation = 8.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 18.dp, vertical = 18.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = null
+                        )
+                    }
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = { showFilterDialog = true }) {
+                        Icon(
+                            painter = painterResource(Res.drawable.pencil),
+                            contentDescription = stringResource(Res.string.menu_fragment_summary_filter_title)
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                if (items.isEmpty()) {
+                    Text(text = "-")
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f, fill = false)
+                    ) {
+                        items(items) { item ->
+                            Surface(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 6.dp)
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .clickable(
+                                        enabled = item.traitId != null,
+                                        onClick = { item.traitId?.let(onTraitSelected) }
+                                    ),
+                                shape = RoundedCornerShape(12.dp),
+                                tonalElevation = 1.dp,
+                                shadowElevation = 0.dp,
+                                border = if (item.traitId != null) {
+                                    androidx.compose.foundation.BorderStroke(
+                                        1.dp,
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)
+                                    )
+                                } else {
+                                    androidx.compose.foundation.BorderStroke(
+                                        1.dp,
+                                        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                                    )
+                                }
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 14.dp, vertical = 12.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(
+                                            text = item.label,
+                                            style = MaterialTheme.typography.labelLarge,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                        Spacer(modifier = Modifier.height(4.dp))
+                                        Text(
+                                            text = item.value,
+                                            style = MaterialTheme.typography.titleSmall,
+                                            fontWeight = if (item.traitId != null) FontWeight.SemiBold else FontWeight.Medium,
+                                            color = if (item.traitId != null) {
+                                                MaterialTheme.colorScheme.primary
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurface
+                                            }
+                                        )
+                                    }
+                                    if (item.traitId != null) {
+                                        Icon(
+                                            painter = painterResource(Res.drawable.chevron_right),
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(
+                        onClick = onPrevious,
+                        enabled = canNavigatePrevious,
+                        modifier = Modifier.size(42.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(Res.drawable.chevron_left),
+                            contentDescription = stringResource(Res.string.fragment_summary_prev_button_text)
+                        )
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
+                    IconButton(
+                        onClick = onNext,
+                        enabled = canNavigateNext,
+                        modifier = Modifier.size(42.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(Res.drawable.chevron_right),
+                            contentDescription = stringResource(Res.string.fragment_summary_next_button_text)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showFilterDialog) {
+        CollectSummaryFilterDialog(
+            title = stringResource(Res.string.fragment_summary_filter_title),
+            toggleAllLabel = stringResource(Res.string.dialog_fragment_summary_neutral_button),
+            options = filterOptions,
+            initialFilter = initialFilter,
+            onApply = {
+                onFilterUpdated(it)
+                showFilterDialog = false
+            },
+            onDismiss = { showFilterDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun CollectSummaryFilterDialog(
+    title: String,
+    toggleAllLabel: String,
+    options: List<CollectSummaryDefinition>,
+    initialFilter: CollectSummaryFilter,
+    onApply: (CollectSummaryFilter) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val initialAttributeSelection = remember(initialFilter, options) {
+        options.filter { it.traitId == null }.associate { option ->
+            option.label to (initialFilter.attributeLabels?.contains(option.label) ?: true)
+        }.toMutableMap()
+    }
+    val initialTraitSelection = remember(initialFilter, options) {
+        options.filter { it.traitId != null }.associate { option ->
+            option.traitId!! to (initialFilter.traitIds?.contains(option.traitId) ?: true)
+        }.toMutableMap()
+    }
+
+    var attributeSelection by remember(initialFilter, options) { mutableStateOf(initialAttributeSelection) }
+    var traitSelection by remember(initialFilter, options) { mutableStateOf(initialTraitSelection) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            LazyColumn {
+                items(options) { option ->
+                    val checked = if (option.traitId == null) {
+                        attributeSelection[option.label] ?: true
+                    } else {
+                        traitSelection[option.traitId] ?: true
+                    }
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(10.dp))
+                            .clickable {
+                                if (option.traitId == null) {
+                                    attributeSelection = attributeSelection.toMutableMap().apply {
+                                        put(option.label, !checked)
+                                    }
+                                } else {
+                                    traitSelection = traitSelection.toMutableMap().apply {
+                                        put(option.traitId, !checked)
+                                    }
+                                }
+                            }
+                            .padding(vertical = 1.dp, horizontal = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = checked,
+                            onCheckedChange = { isChecked ->
+                                if (option.traitId == null) {
+                                    attributeSelection = attributeSelection.toMutableMap().apply {
+                                        put(option.label, isChecked)
+                                    }
+                                } else {
+                                    traitSelection = traitSelection.toMutableMap().apply {
+                                        put(option.traitId, isChecked)
+                                    }
+                                }
+                            }
+                        )
+                        Text(
+                            text = option.label,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(start = 6.dp)
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(
+                    onClick = {
+                        val enableAll = attributeSelection.values.any { !it } || traitSelection.values.any { !it }
+                        attributeSelection = attributeSelection.mapValues { enableAll }.toMutableMap()
+                        traitSelection = traitSelection.mapValues { enableAll }.toMutableMap()
+                    }
+                ) {
+                    Text(toggleAllLabel)
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                TextButton(onClick = onDismiss) {
+                    Text("Cancel")
+                }
+                TextButton(
+                    onClick = {
+                        onApply(
+                            CollectSummaryFilter(
+                                attributeLabels = attributeSelection.filterValues { it }.keys,
+                                traitIds = traitSelection.filterValues { it }.keys
+                            )
+                        )
+                    }
+                ) {
+                    Text("OK")
+                }
+            }
+        }
+    )
+}
+
+private fun loadCollectSummaryFilter(
+    settings: Settings,
+    studyId: Int,
+): CollectSummaryFilter {
+    val attributeKey = "${GeneralKeys.SUMMARY_FILTER_ATTRIBUTES.key}.$studyId"
+    val traitKey = "${GeneralKeys.SUMMARY_FILTER_TRAITS.key}.$studyId"
+
+    val attributeLabels = settings.getStringOrNull(attributeKey)
+        ?.takeIf { it.isNotBlank() }
+        ?.split("\n")
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?.toSet()
+        ?.takeIf { it.isNotEmpty() }
+
+    val traitIds = settings.getStringOrNull(traitKey)
+        ?.takeIf { it.isNotBlank() }
+        ?.split(",")
+        ?.mapNotNull { it.trim().toLongOrNull() }
+        ?.toSet()
+        ?.takeIf { it.isNotEmpty() }
+
+    return CollectSummaryFilter(
+        attributeLabels = attributeLabels,
+        traitIds = traitIds
+    )
+}
+
+private fun persistCollectSummaryFilter(
+    settings: Settings,
+    studyId: Int,
+    filter: CollectSummaryFilter,
+) {
+    val attributeKey = "${GeneralKeys.SUMMARY_FILTER_ATTRIBUTES.key}.$studyId"
+    val traitKey = "${GeneralKeys.SUMMARY_FILTER_TRAITS.key}.$studyId"
+
+    val serializedAttributes = filter.attributeLabels
+        ?.takeIf { it.isNotEmpty() }
+        ?.joinToString("\n")
+        .orEmpty()
+    val serializedTraits = filter.traitIds
+        ?.takeIf { it.isNotEmpty() }
+        ?.joinToString(",")
+        .orEmpty()
+
+    settings.putString(attributeKey, serializedAttributes)
+    settings.putString(traitKey, serializedTraits)
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
@@ -40,7 +40,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.ic_field
+import com.fieldbook.shared.generated.resources.ic_lock_clock
+import com.fieldbook.shared.generated.resources.ic_tb_lock
 import com.fieldbook.shared.generated.resources.ic_transfer_error
+import com.fieldbook.shared.generated.resources.ic_tb_unlock
 import com.fieldbook.shared.preferences.PreferenceKeys
 import com.fieldbook.shared.screens.collect.traits.PhotoTrait
 import com.fieldbook.shared.screens.collect.traits.PhotoTraitDisplayMode
@@ -156,6 +159,19 @@ fun CollectScreen(
                                 contentDescription = "Data Grid"
                             )
                         }
+                    }
+                    IconButton(
+                        onClick = { controller.cycleDataLockState() }
+                    ) {
+                        val lockIcon = when (controller.dataLockState) {
+                            CollectDataLockState.UNLOCKED -> Res.drawable.ic_tb_unlock
+                            CollectDataLockState.LOCKED -> Res.drawable.ic_tb_lock
+                            CollectDataLockState.FROZEN -> Res.drawable.ic_lock_clock
+                        }
+                        Icon(
+                            painter = painterResource(lockIcon),
+                            contentDescription = "Data lock"
+                        )
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
@@ -75,6 +75,9 @@ import com.fieldbook.shared.database.repository.ObservationUnitAttributeReposito
 import com.fieldbook.shared.database.repository.ObservationUnitPropertyRepository
 import com.fieldbook.shared.preferences.GeneralKeys
 import com.fieldbook.shared.preferences.PreferenceKeys
+import com.fieldbook.shared.preferences.loadToolbarCustomizationPreference
+import com.fieldbook.shared.preferences.loadStringSetPreference
+import com.fieldbook.shared.preferences.persistStringSetPreference
 import com.fieldbook.shared.screens.ScannerScreen
 import com.fieldbook.shared.screens.collect.traits.PhotoTrait
 import com.fieldbook.shared.screens.collect.traits.PhotoTraitDisplayMode
@@ -311,7 +314,7 @@ fun CollectScreen(
                 canSetNa = !controller.isCurrentObservationLocked(),
                 canDeleteCurrentValue = canDeleteCurrentValue,
                 onScanBarcode = { isBarcodeScannerFullscreen = true },
-                onSetNa = { controller.updateCurrentTraitValue("NA") },
+                onSetNa = controller::setCurrentTraitNa,
                 onDelete = controller::clearCurrentTraitValue
             )
         }
@@ -780,20 +783,19 @@ private fun loadCollectSummaryFilter(
     val attributeKey = "${GeneralKeys.SUMMARY_FILTER_ATTRIBUTES.key}.$studyId"
     val traitKey = "${GeneralKeys.SUMMARY_FILTER_TRAITS.key}.$studyId"
 
-    val attributeLabels = settings.getStringOrNull(attributeKey)
-        ?.takeIf { it.isNotBlank() }
-        ?.split("\n")
-        ?.map { it.trim() }
-        ?.filter { it.isNotEmpty() }
-        ?.toSet()
-        ?.takeIf { it.isNotEmpty() }
+    val attributeLabels = loadStringSetPreference(
+        settings = settings,
+        key = attributeKey,
+        legacySeparators = charArrayOf('\n')
+    )
 
-    val traitIds = settings.getStringOrNull(traitKey)
-        ?.takeIf { it.isNotBlank() }
-        ?.split(",")
+    val traitIds = loadStringSetPreference(
+        settings = settings,
+        key = traitKey,
+        legacySeparators = charArrayOf(',')
+    )
         ?.mapNotNull { it.trim().toLongOrNull() }
         ?.toSet()
-        ?.takeIf { it.isNotEmpty() }
 
     return CollectSummaryFilter(
         attributeLabels = attributeLabels,
@@ -802,16 +804,11 @@ private fun loadCollectSummaryFilter(
 }
 
 private fun loadCollectToolbarCustomization(settings: Settings): Set<String> {
-    val serialized = settings.getStringOrNull(PreferenceKeys.TOOLBAR_CUSTOMIZE)
-    if (serialized == null) {
-        return setOf("summary", "lockData")
-    }
-
-    return serialized
-        .split(',', '\n')
-        .map { it.trim() }
-        .filter { it.isNotEmpty() }
-        .toSet()
+    return loadToolbarCustomizationPreference(
+        settings = settings,
+        key = PreferenceKeys.TOOLBAR_CUSTOMIZE,
+        defaultOptions = setOf("summary", "lockData")
+    )
 }
 
 private fun persistCollectSummaryFilter(
@@ -822,17 +819,16 @@ private fun persistCollectSummaryFilter(
     val attributeKey = "${GeneralKeys.SUMMARY_FILTER_ATTRIBUTES.key}.$studyId"
     val traitKey = "${GeneralKeys.SUMMARY_FILTER_TRAITS.key}.$studyId"
 
-    val serializedAttributes = filter.attributeLabels
-        ?.takeIf { it.isNotEmpty() }
-        ?.joinToString("\n")
-        .orEmpty()
-    val serializedTraits = filter.traitIds
-        ?.takeIf { it.isNotEmpty() }
-        ?.joinToString(",")
-        .orEmpty()
-
-    settings.putString(attributeKey, serializedAttributes)
-    settings.putString(traitKey, serializedTraits)
+    persistStringSetPreference(
+        settings = settings,
+        key = attributeKey,
+        values = filter.attributeLabels ?: emptySet()
+    )
+    persistStringSetPreference(
+        settings = settings,
+        key = traitKey,
+        values = filter.traitIds?.map { it.toString() }?.toSet() ?: emptySet()
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
@@ -1,14 +1,14 @@
 package com.fieldbook.shared.screens.collect
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -50,33 +50,33 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.fieldbook.shared.database.repository.ObservationUnitAttributeRepository
+import com.fieldbook.shared.database.repository.ObservationUnitPropertyRepository
 import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.act_collect_barcode_button_content_description
+import com.fieldbook.shared.generated.resources.act_collect_delete_value_button_content_description
+import com.fieldbook.shared.generated.resources.chevron_left
+import com.fieldbook.shared.generated.resources.chevron_right
+import com.fieldbook.shared.generated.resources.dialog_fragment_summary_neutral_button
+import com.fieldbook.shared.generated.resources.fragment_summary_filter_title
+import com.fieldbook.shared.generated.resources.fragment_summary_next_button_text
+import com.fieldbook.shared.generated.resources.fragment_summary_prev_button_text
+import com.fieldbook.shared.generated.resources.fragment_summary_toolbar_title
 import com.fieldbook.shared.generated.resources.ic_field
 import com.fieldbook.shared.generated.resources.ic_lock_clock
 import com.fieldbook.shared.generated.resources.ic_tb_barcode
 import com.fieldbook.shared.generated.resources.ic_tb_delete
 import com.fieldbook.shared.generated.resources.ic_tb_details
 import com.fieldbook.shared.generated.resources.ic_tb_lock
-import com.fieldbook.shared.generated.resources.ic_transfer_error
 import com.fieldbook.shared.generated.resources.ic_tb_unlock
-import com.fieldbook.shared.generated.resources.act_collect_delete_value_button_content_description
-import com.fieldbook.shared.generated.resources.fragment_summary_toolbar_title
-import com.fieldbook.shared.generated.resources.fragment_summary_filter_title
-import com.fieldbook.shared.generated.resources.fragment_summary_next_button_text
-import com.fieldbook.shared.generated.resources.fragment_summary_prev_button_text
-import com.fieldbook.shared.generated.resources.dialog_fragment_summary_neutral_button
-import com.fieldbook.shared.generated.resources.chevron_left
-import com.fieldbook.shared.generated.resources.chevron_right
+import com.fieldbook.shared.generated.resources.ic_transfer_error
 import com.fieldbook.shared.generated.resources.menu_fragment_summary_filter_title
 import com.fieldbook.shared.generated.resources.pencil
 import com.fieldbook.shared.generated.resources.preferences_appearance_toolbar_customize_summary
-import com.fieldbook.shared.database.repository.ObservationUnitAttributeRepository
-import com.fieldbook.shared.database.repository.ObservationUnitPropertyRepository
 import com.fieldbook.shared.preferences.GeneralKeys
 import com.fieldbook.shared.preferences.PreferenceKeys
-import com.fieldbook.shared.preferences.loadToolbarCustomizationPreference
 import com.fieldbook.shared.preferences.loadStringSetPreference
+import com.fieldbook.shared.preferences.loadToolbarCustomizationPreference
 import com.fieldbook.shared.preferences.persistStringSetPreference
 import com.fieldbook.shared.screens.ScannerScreen
 import com.fieldbook.shared.screens.collect.traits.PhotoTrait
@@ -846,6 +846,7 @@ private fun CollectBottomBar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .navigationBarsPadding()
                 .padding(horizontal = 16.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
@@ -106,6 +106,9 @@ fun CollectScreen(
     val dataGridEnabled = remember {
         settings.getBoolean(PreferenceKeys.DATAGRID_SETTING, false)
     }
+    val toolbarCustomization = loadCollectToolbarCustomization(settings)
+    val summaryEnabled = "summary" in toolbarCustomization
+    val lockEnabled = "lockData" in toolbarCustomization
     val handleBack: () -> Unit = {
         controller.persistCurrentSelection()
         onBack?.invoke()
@@ -267,27 +270,31 @@ fun CollectScreen(
                             )
                         }
                     }
-                    IconButton(
-                        onClick = { showSummaryDialog = true },
-                        enabled = !controller.collectInteractionLocked
-                    ) {
-                        Icon(
-                            painter = painterResource(Res.drawable.ic_tb_details),
-                            contentDescription = stringResource(Res.string.preferences_appearance_toolbar_customize_summary)
-                        )
-                    }
-                    IconButton(
-                        onClick = { controller.cycleDataLockState() }
-                    ) {
-                        val lockIcon = when (controller.dataLockState) {
-                            CollectDataLockState.UNLOCKED -> Res.drawable.ic_tb_unlock
-                            CollectDataLockState.LOCKED -> Res.drawable.ic_tb_lock
-                            CollectDataLockState.FROZEN -> Res.drawable.ic_lock_clock
+                    if (summaryEnabled) {
+                        IconButton(
+                            onClick = { showSummaryDialog = true },
+                            enabled = !controller.collectInteractionLocked
+                        ) {
+                            Icon(
+                                painter = painterResource(Res.drawable.ic_tb_details),
+                                contentDescription = stringResource(Res.string.preferences_appearance_toolbar_customize_summary)
+                            )
                         }
-                        Icon(
-                            painter = painterResource(lockIcon),
-                            contentDescription = "Data lock"
-                        )
+                    }
+                    if (lockEnabled) {
+                        IconButton(
+                            onClick = { controller.cycleDataLockState() }
+                        ) {
+                            val lockIcon = when (controller.dataLockState) {
+                                CollectDataLockState.UNLOCKED -> Res.drawable.ic_tb_unlock
+                                CollectDataLockState.LOCKED -> Res.drawable.ic_tb_lock
+                                CollectDataLockState.FROZEN -> Res.drawable.ic_lock_clock
+                            }
+                            Icon(
+                                painter = painterResource(lockIcon),
+                                contentDescription = "Data lock"
+                            )
+                        }
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -792,6 +799,19 @@ private fun loadCollectSummaryFilter(
         attributeLabels = attributeLabels,
         traitIds = traitIds
     )
+}
+
+private fun loadCollectToolbarCustomization(settings: Settings): Set<String> {
+    val serialized = settings.getStringOrNull(PreferenceKeys.TOOLBAR_CUSTOMIZE)
+    if (serialized == null) {
+        return setOf("summary", "lockData")
+    }
+
+    return serialized
+        .split(',', '\n')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .toSet()
 }
 
 private fun persistCollectSummaryFilter(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreen.kt
@@ -43,18 +43,22 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.act_collect_barcode_button_content_description
 import com.fieldbook.shared.generated.resources.ic_field
 import com.fieldbook.shared.generated.resources.ic_lock_clock
+import com.fieldbook.shared.generated.resources.ic_tb_barcode
 import com.fieldbook.shared.generated.resources.ic_tb_delete
 import com.fieldbook.shared.generated.resources.ic_tb_lock
 import com.fieldbook.shared.generated.resources.ic_transfer_error
 import com.fieldbook.shared.generated.resources.ic_tb_unlock
 import com.fieldbook.shared.generated.resources.act_collect_delete_value_button_content_description
 import com.fieldbook.shared.preferences.PreferenceKeys
+import com.fieldbook.shared.screens.ScannerScreen
 import com.fieldbook.shared.screens.collect.traits.PhotoTrait
 import com.fieldbook.shared.screens.collect.traits.PhotoTraitDisplayMode
 import com.fieldbook.shared.screens.datagrid.DataGridScreen
 import com.fieldbook.shared.traits.Formats
+import com.fieldbook.shared.traits.Scannable
 import com.russhwolf.settings.Settings
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -71,6 +75,7 @@ fun CollectScreen(
     onBack: (() -> Unit)? = null,
 ) {
     var isCameraFullscreen by remember { mutableStateOf(false) }
+    var isBarcodeScannerFullscreen by remember { mutableStateOf(false) }
     var showDataGrid by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
     val settings = remember { Settings() }
@@ -117,6 +122,25 @@ fun CollectScreen(
                 controller = controller,
                 displayMode = PhotoTraitDisplayMode.FULLSCREEN,
                 onCollapseRequest = { isCameraFullscreen = false }
+            )
+        }
+        return
+    }
+
+    if (isBarcodeScannerFullscreen) {
+        Surface(modifier = modifier.fillMaxSize()) {
+            ScannerScreen(
+                onBack = { isBarcodeScannerFullscreen = false },
+                onResult = { scannedValue ->
+                    val traitFormat = currentTrait?.format
+                        ?.let { Formats.findTrait(it) }
+                    val valueToStore = when (traitFormat) {
+                        is Scannable -> traitFormat.preprocess(scannedValue)
+                        else -> scannedValue
+                    }
+                    controller.updateCurrentTraitValue(valueToStore)
+                    isBarcodeScannerFullscreen = false
+                }
             )
         }
         return
@@ -192,8 +216,10 @@ fun CollectScreen(
         },
         bottomBar = {
             CollectBottomBar(
+                canScanBarcode = !controller.isCurrentObservationLocked(),
                 canSetNa = !controller.isCurrentObservationLocked(),
                 canDeleteCurrentValue = canDeleteCurrentValue,
+                onScanBarcode = { isBarcodeScannerFullscreen = true },
                 onSetNa = { controller.updateCurrentTraitValue("NA") },
                 onDelete = controller::clearCurrentTraitValue
             )
@@ -244,8 +270,10 @@ fun CollectScreen(
 
 @Composable
 private fun CollectBottomBar(
+    canScanBarcode: Boolean,
     canSetNa: Boolean,
     canDeleteCurrentValue: Boolean,
+    onScanBarcode: () -> Unit,
     onSetNa: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -258,18 +286,24 @@ private fun CollectBottomBar(
                 .padding(horizontal = 16.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Spacer(modifier = Modifier.weight(1f))
             Box(
                 modifier = Modifier.weight(1f),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = "NA",
-                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.alpha(0f)
-                )
+                IconButton(
+                    onClick = onScanBarcode,
+                    enabled = canScanBarcode,
+                ) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_tb_barcode),
+                        contentDescription = stringResource(Res.string.act_collect_barcode_button_content_description),
+                        tint = if (canScanBarcode) {
+                            MaterialTheme.colorScheme.onPrimary
+                        } else {
+                            MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f)
+                        }
+                    )
+                }
             }
             Box(
                 modifier = Modifier
@@ -287,7 +321,8 @@ private fun CollectBottomBar(
                     },
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.alpha(if (canSetNa) 1f else 0.38f)
                 )
             }
             Box(
@@ -309,7 +344,6 @@ private fun CollectBottomBar(
                     )
                 }
             }
-            Spacer(modifier = Modifier.weight(1f))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
@@ -13,8 +13,11 @@ import com.fieldbook.shared.database.repository.ObservationUnitRepository
 import com.fieldbook.shared.database.repository.StudyRepository
 import com.fieldbook.shared.database.repository.TraitRepository
 import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.activity_collect_frozen_state
+import com.fieldbook.shared.generated.resources.activity_collect_locked_state
 import com.fieldbook.shared.generated.resources.trait_error_maximum_value
 import com.fieldbook.shared.generated.resources.trait_error_minimum_value
+import com.fieldbook.shared.generated.resources.activity_collect_unlocked_state
 import com.fieldbook.shared.objects.RangeObject
 import com.fieldbook.shared.preferences.GeneralKeys
 import com.fieldbook.shared.screens.datagrid.DataGridSelection
@@ -24,6 +27,17 @@ import com.russhwolf.settings.Settings
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
 
+enum class CollectDataLockState(val persistedValue: Int) {
+    UNLOCKED(0),
+    LOCKED(1),
+    FROZEN(2);
+
+    companion object {
+        fun fromPersistedValue(value: Int): CollectDataLockState {
+            return entries.firstOrNull { it.persistedValue == value } ?: UNLOCKED
+        }
+    }
+}
 
 // TODO refactor to use ViewModel() ?
 class CollectScreenController {
@@ -70,7 +84,14 @@ class CollectScreenController {
         private set
     var collectInteractionLocked by mutableStateOf(false)
         private set
+    var dataLockState by mutableStateOf(
+        CollectDataLockState.fromPersistedValue(
+            settings.getInt(GeneralKeys.DATA_LOCK_STATE.key, CollectDataLockState.UNLOCKED.persistedValue)
+        )
+    )
+        private set
     private val suppressedDefaultEntries = mutableSetOf<String>()
+    private var currentObservationHadInitialValue by mutableStateOf(false)
 
     val primaryId = settings.getString(GeneralKeys.PRIMARY_NAME.key, "")
     val secondaryId = settings.getString(GeneralKeys.SECONDARY_NAME.key, "")
@@ -130,6 +151,7 @@ class CollectScreenController {
             rangeID.getOrNull(index)?.let(::updateCurrentRange)
             persistCurrentSelection()
             loadTraitValues()
+            refreshCurrentObservationLockState()
             return true
         }
         return false
@@ -151,6 +173,7 @@ class CollectScreenController {
         if (index in traits.indices && validateCurrentTraitValue()) {
             currentTraitIndex = index
             persistCurrentSelection()
+            refreshCurrentObservationLockState()
             return true
         }
         return false
@@ -194,12 +217,17 @@ class CollectScreenController {
             traitValuesLoading = false
             lastUnitId = plotId
         }
+        refreshCurrentObservationLockState()
     }
 
     /**
      * Update the observation for the current trait and unit, and persist to DB.
      */
     fun updateCurrentTraitValue(value: String) {
+        if (!canMutateCurrentObservation()) {
+            showCurrentDataLockMessage()
+            return
+        }
         val trait = traits.getOrNull(currentTraitIndex)
         val unit = units.getOrNull(currentUnitIndex)
         val plotId = unit?.observation_unit_db_id
@@ -225,6 +253,10 @@ class CollectScreenController {
     }
 
     fun updateCurrentUnitGeoCoordinates(geoCoordinates: String) {
+        if (!canMutateCurrentObservation()) {
+            showCurrentDataLockMessage()
+            return
+        }
         val unit = units.getOrNull(currentUnitIndex)
         val unitDbId = unit?.observation_unit_db_id ?: return
 
@@ -280,6 +312,10 @@ class CollectScreenController {
      * Add a new observation for the current trait and unit, and persist to DB.
      */
     fun addCurrentTraitValue(value: String) {
+        if (!canMutateCurrentObservation()) {
+            showCurrentDataLockMessage()
+            return
+        }
         val trait = traits.getOrNull(currentTraitIndex)
         val unit = units.getOrNull(currentUnitIndex)
         val plotId = unit?.observation_unit_db_id
@@ -302,6 +338,10 @@ class CollectScreenController {
      * Remove one stored value for the current trait and unit.
      */
     fun deleteCurrentTraitValue(value: String) {
+        if (!canMutateCurrentObservation()) {
+            showCurrentDataLockMessage()
+            return
+        }
         val trait = traits.getOrNull(currentTraitIndex)
         val unit = units.getOrNull(currentUnitIndex)
         val plotId = unit?.observation_unit_db_id
@@ -351,7 +391,41 @@ class CollectScreenController {
         collectInteractionLocked = locked
     }
 
+    fun cycleDataLockState() {
+        dataLockState = when (dataLockState) {
+            CollectDataLockState.UNLOCKED -> CollectDataLockState.LOCKED
+            CollectDataLockState.LOCKED -> CollectDataLockState.FROZEN
+            CollectDataLockState.FROZEN -> CollectDataLockState.UNLOCKED
+        }
+        settings.putInt(GeneralKeys.DATA_LOCK_STATE.key, dataLockState.persistedValue)
+        showCurrentDataLockMessage()
+    }
+
+    fun isCurrentObservationLocked(): Boolean {
+        return when (dataLockState) {
+            CollectDataLockState.UNLOCKED -> false
+            CollectDataLockState.LOCKED -> true
+            CollectDataLockState.FROZEN -> currentObservationHadInitialValue
+        }
+    }
+
+    fun canMutateCurrentObservation(): Boolean = !isCurrentObservationLocked()
+
+    fun showCurrentDataLockMessage() {
+        inputValidationMessage = runBlocking {
+            when (dataLockState) {
+                CollectDataLockState.UNLOCKED -> getString(Res.string.activity_collect_unlocked_state)
+                CollectDataLockState.LOCKED -> getString(Res.string.activity_collect_locked_state)
+                CollectDataLockState.FROZEN -> getString(Res.string.activity_collect_frozen_state)
+            }
+        }
+    }
+
     fun clearCurrentTraitValue() {
+        if (!canMutateCurrentObservation()) {
+            showCurrentDataLockMessage()
+            return
+        }
         val trait = traits.getOrNull(currentTraitIndex)
         val unit = units.getOrNull(currentUnitIndex)
         val plotId = unit?.observation_unit_db_id
@@ -369,6 +443,7 @@ class CollectScreenController {
             traitValues = traitValues.toMutableMap().apply {
                 remove(traitId)
             }
+            refreshCurrentObservationLockState()
         }
     }
 
@@ -425,6 +500,13 @@ class CollectScreenController {
 
         val restoredIndex = traits.indexOfFirst { it.id?.toString() == lastTraitId }
         currentTraitIndex = if (restoredIndex >= 0) restoredIndex else 0
+        refreshCurrentObservationLockState()
+    }
+
+    private fun refreshCurrentObservationLockState() {
+        val traitId = traits.getOrNull(currentTraitIndex)?.id
+        val currentValue = traitId?.let { traitValues[it]?.firstOrNull() }.orEmpty()
+        currentObservationHadInitialValue = currentValue.isNotEmpty()
     }
 
     private fun currentRangeUniqueId(): String? {

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
@@ -135,6 +135,18 @@ class CollectScreenController {
         return false
     }
 
+    fun goToNextUnit(): Boolean {
+        if (units.isEmpty()) return false
+        val nextIndex = if (currentUnitIndex >= units.lastIndex) 0 else currentUnitIndex + 1
+        return updateCurrentUnitIndex(nextIndex)
+    }
+
+    fun goToPreviousUnit(): Boolean {
+        if (units.isEmpty()) return false
+        val previousIndex = if (currentUnitIndex <= 0) units.lastIndex else currentUnitIndex - 1
+        return updateCurrentUnitIndex(previousIndex)
+    }
+
     fun updateCurrentTraitIndex(index: Int): Boolean {
         if (index in traits.indices && validateCurrentTraitValue()) {
             currentTraitIndex = index
@@ -142,6 +154,18 @@ class CollectScreenController {
             return true
         }
         return false
+    }
+
+    fun goToNextTrait(): Boolean {
+        if (traits.isEmpty()) return false
+        val nextIndex = if (currentTraitIndex >= traits.lastIndex) 0 else currentTraitIndex + 1
+        return updateCurrentTraitIndex(nextIndex)
+    }
+
+    fun goToPreviousTrait(): Boolean {
+        if (traits.isEmpty()) return false
+        val previousIndex = if (currentTraitIndex <= 0) traits.lastIndex else currentTraitIndex - 1
+        return updateCurrentTraitIndex(previousIndex)
     }
 
     fun applyDataGridSelection(selection: DataGridSelection): Boolean {

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
@@ -411,6 +411,11 @@ class CollectScreenController {
 
     fun canMutateCurrentObservation(): Boolean = !isCurrentObservationLocked()
 
+    fun hasCurrentTraitValue(): Boolean {
+        val traitId = traits.getOrNull(currentTraitIndex)?.id ?: return false
+        return traitValues[traitId]?.firstOrNull().isNullOrBlank().not()
+    }
+
     fun showCurrentDataLockMessage() {
         inputValidationMessage = runBlocking {
             when (dataLockState) {

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/CollectScreenController.kt
@@ -252,6 +252,10 @@ class CollectScreenController {
         }
     }
 
+    fun setCurrentTraitNa() {
+        updateCurrentTraitValue("NA")
+    }
+
     fun updateCurrentUnitGeoCoordinates(geoCoordinates: String) {
         if (!canMutateCurrentObservation()) {
             showCurrentDataLockMessage()
@@ -321,15 +325,25 @@ class CollectScreenController {
         val plotId = unit?.observation_unit_db_id
 
         if (plotId != null && trait?.id != null) {
+            val traitId = trait.id!!
+            val currentList = traitValues[traitId].orEmpty()
+            if (currentList.size == 1 && currentList.first() == "NA") {
+                observationRepository.deleteTraitByValue(
+                    plotId = plotId,
+                    traitDbId = traitId,
+                    value = "NA",
+                    studyId = studyId.toLong()
+                )
+            }
             observationRepository.insertObservation(
                 plotId = plotId,
-                traitDbId = trait.id!!,
+                traitDbId = traitId,
                 value = value,
                 studyId = studyId.toLong()
             )
             traitValues = traitValues.toMutableMap().apply {
-                val currentList = get(trait.id!!) ?: emptyList()
-                put(trait.id!!, currentList + value)
+                val sanitizedCurrentList = currentList.filterNot { it == "NA" }
+                put(traitId, sanitizedCurrentList + value)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/InfoBar.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/InfoBar.kt
@@ -1,34 +1,546 @@
 package com.fieldbook.shared.screens.collect
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.fieldbook.shared.database.models.TraitObject
+import com.fieldbook.shared.database.repository.ObservationUnitAttributeRepository
+import com.fieldbook.shared.database.repository.ObservationUnitPropertyRepository
+import com.fieldbook.shared.database.repository.TraitRepository
+import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.dialog_att_chooser_attributes
+import com.fieldbook.shared.generated.resources.dialog_att_chooser_customize
+import com.fieldbook.shared.generated.resources.dialog_att_chooser_other
+import com.fieldbook.shared.generated.resources.dialog_att_chooser_traits
+import com.fieldbook.shared.generated.resources.dialog_infobar_att_chooser_title
+import com.fieldbook.shared.generated.resources.field_name_attribute
+import com.fieldbook.shared.generated.resources.ic_infobar_circle
+import com.fieldbook.shared.generated.resources.ic_infobar_circle_outline
+import com.fieldbook.shared.generated.resources.ic_infobar_hexagon
+import com.fieldbook.shared.generated.resources.ic_infobar_hexagon_outline
+import com.fieldbook.shared.generated.resources.ic_infobar_pentagon
+import com.fieldbook.shared.generated.resources.ic_infobar_pentagon_outline
+import com.fieldbook.shared.generated.resources.ic_infobar_rhombus
+import com.fieldbook.shared.generated.resources.ic_infobar_rhombus_outline
+import com.fieldbook.shared.generated.resources.ic_infobar_square_rounded
+import com.fieldbook.shared.generated.resources.ic_infobar_square_rounded_outline
+import com.fieldbook.shared.generated.resources.ic_infobar_triangle
+import com.fieldbook.shared.generated.resources.ic_infobar_triangle_outline
+import com.fieldbook.shared.generated.resources.main_infobar_data_missing
+import com.fieldbook.shared.generated.resources.preferences_appearance_infobar_number
+import com.fieldbook.shared.generated.resources.preferences_appearance_infobar_number_description
+import com.fieldbook.shared.preferences.GeneralKeys
+import com.fieldbook.shared.preferences.PreferenceKeys
+import com.fieldbook.shared.screens.components.NumberStepperDialog
+import com.fieldbook.shared.utilities.CategoryJsonUtil
+import com.russhwolf.settings.Settings
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+private const val DefaultInfoBarTraitId = "-1"
+
+private data class InfoBarSelection(
+    val label: String,
+    val traitId: Long? = null,
+)
+
+private data class InfoBarItem(
+    val selection: InfoBarSelection,
+    val value: String,
+)
+
+private enum class InfoBarDialogTab(val title: StringResource) {
+    ATTRIBUTES(Res.string.dialog_att_chooser_attributes),
+    TRAITS(Res.string.dialog_att_chooser_traits),
+    OTHER(Res.string.dialog_att_chooser_other),
+}
 
 @Composable
+@OptIn(ExperimentalFoundationApi::class)
 fun InfoBar(controller: CollectScreenController, modifier: Modifier = Modifier) {
+    val settings = remember { Settings() }
+    val attributeRepository = remember { ObservationUnitAttributeRepository() }
+    val propertyRepository = remember { ObservationUnitPropertyRepository() }
+    val traitRepository = remember { TraitRepository() }
     val unit = controller.units.getOrNull(controller.currentUnitIndex)
+    val hidePrefixEnabled = settings.getBoolean(PreferenceKeys.HIDE_INFOBAR_PREFIX, false)
+    var infoBarCount by remember {
+        mutableStateOf(settings.getInt(PreferenceKeys.INFOBAR_NUMBER, 3).coerceIn(1, 20))
+    }
+    val fieldNameLabel = stringResource(Res.string.field_name_attribute)
+    val noDataLabel = stringResource(Res.string.main_infobar_data_missing)
+    val showCategoryLabels = settings.getString(PreferenceKeys.LABELVAL_CUSTOMIZE, "value") != "value"
 
-    /*
-     * TODO configurable info bar fields
-     */
+    val availableAttributes = remember(controller.studyId, fieldNameLabel) {
+        buildList {
+            add(fieldNameLabel)
+            addAll(
+                attributeRepository.getAllNames(controller.studyId.toLong())
+                    .filter { it != fieldNameLabel }
+            )
+        }
+    }
+    val allTraits = remember(controller.studyId) {
+        traitRepository.getAllTraitsWithAttributes()
+    }
+    val visibleTraits = remember(allTraits) {
+        allTraits.filter { it.visible == "true" }
+    }
+    val hiddenTraits = remember(allTraits) {
+        allTraits.filter { it.visible != "true" }
+    }
+    val defaultSelectionOrder = remember(
+        availableAttributes,
+        controller.primaryId,
+        controller.secondaryId,
+        fieldNameLabel
+    ) {
+        buildList {
+            add("plot_id")
+            controller.primaryId.takeIf { it.isNotBlank() }?.let(::add)
+            controller.secondaryId.takeIf { it.isNotBlank() }?.let(::add)
+            add(fieldNameLabel)
+            addAll(availableAttributes.filterNot { it in this })
+        }
+    }
+    var selections by remember(
+        infoBarCount,
+        availableAttributes,
+        allTraits,
+        defaultSelectionOrder
+    ) {
+        mutableStateOf(
+            List(infoBarCount) { index ->
+                loadInfoBarSelection(
+                    settings = settings,
+                    index = index,
+                    availableAttributes = availableAttributes,
+                    allTraits = allTraits,
+                    defaultSelectionOrder = defaultSelectionOrder
+                )
+            }
+        )
+    }
+    var wordWrapStates by remember(infoBarCount) {
+        mutableStateOf(
+            List(infoBarCount) { index ->
+                settings.getBoolean(infoBarWordWrapKey(index), false)
+            }
+        )
+    }
+    var activeInfoBarIndex by remember { mutableStateOf<Int?>(null) }
+    var showInfoBarCountDialog by remember { mutableStateOf(false) }
+
+    val fieldNameValue = settings.getString(
+        GeneralKeys.FIELD_ALIAS.key,
+        controller.field.exp_name.ifBlank { noDataLabel }
+    ).ifBlank { controller.field.exp_name.ifBlank { noDataLabel } }
+
+    val attributeLabelsToQuery = selections
+        .filter { it.traitId == null && it.label != fieldNameLabel }
+        .map { it.label }
+        .distinct()
+    val unitId = unit?.observation_unit_db_id.orEmpty()
+    val attributeValues = propertyRepository.getAttributeValuesForUnit(
+        uniqueName = controller.uniqueId,
+        unitId = unitId,
+        attributeLabels = attributeLabelsToQuery
+    )
+
+    val infoBarItems = selections.map { selection ->
+        InfoBarItem(
+            selection = selection,
+            value = resolveInfoBarValue(
+                controller = controller,
+                selection = selection,
+                fieldNameLabel = fieldNameLabel,
+                fieldNameValue = fieldNameValue,
+                noDataLabel = noDataLabel,
+                attributeValues = attributeValues,
+                allTraits = allTraits,
+                showCategoryLabels = showCategoryLabels
+            )
+        )
+    }
 
     Column(modifier = modifier.fillMaxWidth()) {
         Spacer(Modifier.height(8.dp))
-        Text("field_name: ${controller.field.exp_name}", style = MaterialTheme.typography.bodyLarge)
-        Text(
-            "plot_id: ${unit?.observation_unit_db_id ?: "-"}",
-            style = MaterialTheme.typography.bodyLarge
-        )
-        Text(
-            "${controller.primaryId}: ${controller.cRange.primaryId ?: "-"}",
-            style = MaterialTheme.typography.bodyLarge
-        )
+        infoBarItems.forEachIndexed { index, item ->
+            val isWordWrapped = wordWrapStates.getOrElse(index) { false }
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .combinedClickable(
+                        onClick = { activeInfoBarIndex = index },
+                        onLongClick = {
+                            val updatedWrapState = !isWordWrapped
+                            settings.putBoolean(infoBarWordWrapKey(index), updatedWrapState)
+                            wordWrapStates = wordWrapStates.toMutableList().apply {
+                                this[index] = updatedWrapState
+                            }
+                        }
+                    ),
+                color = androidx.compose.ui.graphics.Color.Transparent
+            ) {
+                if (hidePrefixEnabled) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(vertical = 2.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(infoBarIcon(index, isWordWrapped)),
+                            contentDescription = item.selection.label,
+                            modifier = Modifier
+                                .padding(end = 8.dp)
+                                .size(18.dp),
+                            tint = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            text = item.value,
+                            style = MaterialTheme.typography.bodyLarge,
+                            maxLines = if (isWordWrapped) 5 else 1,
+                            overflow = if (isWordWrapped) TextOverflow.Clip else TextOverflow.Ellipsis
+                        )
+                    }
+                } else {
+                    Text(
+                        text = "${item.selection.label}: ${item.value}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        maxLines = if (isWordWrapped) 5 else 1,
+                        overflow = if (isWordWrapped) TextOverflow.Clip else TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
         Spacer(Modifier.height(8.dp))
     }
+
+    activeInfoBarIndex?.let { infoBarIndex ->
+        InfoBarChooserDialog(
+            position = infoBarIndex,
+            selectedSelection = selections.getOrElse(infoBarIndex) {
+                defaultSelectionOrder
+                    .getOrNull(infoBarIndex)
+                    ?.let(::InfoBarSelection)
+                    ?: InfoBarSelection("plot_id")
+            },
+            attributes = availableAttributes,
+            visibleTraits = visibleTraits,
+            hiddenTraits = hiddenTraits,
+            initialTabIndex = settings.getInt(GeneralKeys.ATTR_CHOOSER_DIALOG_TAB.key, 0),
+            onTabChanged = { tabIndex ->
+                settings.putInt(GeneralKeys.ATTR_CHOOSER_DIALOG_TAB.key, tabIndex)
+            },
+            onCustomizeClick = {
+                activeInfoBarIndex = null
+                showInfoBarCountDialog = true
+            },
+            onSelectionChosen = { selection ->
+                persistInfoBarSelection(settings, infoBarIndex, selection)
+                selections = selections.toMutableList().apply {
+                    this[infoBarIndex] = selection
+                }
+                activeInfoBarIndex = null
+            },
+            onDismiss = { activeInfoBarIndex = null }
+        )
+    }
+
+    if (showInfoBarCountDialog) {
+        NumberStepperDialog(
+            title = stringResource(Res.string.preferences_appearance_infobar_number),
+            summary = stringResource(Res.string.preferences_appearance_infobar_number_description),
+            initialValue = infoBarCount,
+            onDismiss = { showInfoBarCountDialog = false },
+            onSave = { updatedCount ->
+                infoBarCount = updatedCount.coerceIn(1, 20)
+                settings.putInt(PreferenceKeys.INFOBAR_NUMBER, infoBarCount)
+                showInfoBarCountDialog = false
+            }
+        )
+    }
+}
+
+@Composable
+private fun InfoBarChooserDialog(
+    position: Int,
+    selectedSelection: InfoBarSelection,
+    attributes: List<String>,
+    visibleTraits: List<TraitObject>,
+    hiddenTraits: List<TraitObject>,
+    initialTabIndex: Int,
+    onTabChanged: (Int) -> Unit,
+    onCustomizeClick: () -> Unit,
+    onSelectionChosen: (InfoBarSelection) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selectedTabIndex by remember(initialTabIndex) {
+        mutableStateOf(initialTabIndex.coerceIn(0, InfoBarDialogTab.entries.lastIndex))
+    }
+
+    val currentChoices = when (InfoBarDialogTab.entries[selectedTabIndex]) {
+        InfoBarDialogTab.ATTRIBUTES -> attributes.map { InfoBarSelection(label = it) }
+        InfoBarDialogTab.TRAITS -> visibleTraits.mapNotNull { trait ->
+            trait.id?.let { InfoBarSelection(label = trait.name, traitId = it) }
+        }
+        InfoBarDialogTab.OTHER -> hiddenTraits.mapNotNull { trait ->
+            trait.id?.let { InfoBarSelection(label = trait.name, traitId = it) }
+        }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp),
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(18.dp),
+            tonalElevation = 6.dp,
+            shadowElevation = 8.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 18.dp, vertical = 18.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = null
+                        )
+                    }
+                    Text(
+                        text = stringResource(
+                            Res.string.dialog_infobar_att_chooser_title,
+                            position + 1
+                        ),
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f)
+                    )
+                    TextButton(onClick = onCustomizeClick) {
+                        Text(stringResource(Res.string.dialog_att_chooser_customize))
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
+
+                TabRow(selectedTabIndex = selectedTabIndex) {
+                    InfoBarDialogTab.entries.forEachIndexed { index, tab ->
+                        Tab(
+                            selected = selectedTabIndex == index,
+                            onClick = {
+                                selectedTabIndex = index
+                                onTabChanged(index)
+                            },
+                            text = { Text(stringResource(tab.title)) }
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(12.dp))
+
+                if (currentChoices.isEmpty()) {
+                    Text(
+                        text = "-",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 12.dp)
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 360.dp)
+                    ) {
+                        items(currentChoices) { choice ->
+                            val isSelected = choice == selectedSelection
+                            Surface(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 4.dp)
+                                    .clickable { onSelectionChosen(choice) },
+                                shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+                                tonalElevation = if (isSelected) 3.dp else 0.dp,
+                                border = BorderStroke(
+                                    1.dp,
+                                    if (isSelected) {
+                                        MaterialTheme.colorScheme.primary
+                                    } else {
+                                        MaterialTheme.colorScheme.outlineVariant
+                                    }
+                                )
+                            ) {
+                                Text(
+                                    text = choice.label,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp)
+                                )
+                            }
+                            HorizontalDivider()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun loadInfoBarSelection(
+    settings: Settings,
+    index: Int,
+    availableAttributes: List<String>,
+    allTraits: List<TraitObject>,
+    defaultSelectionOrder: List<String>,
+): InfoBarSelection {
+    val fallbackLabel = defaultSelectionOrder.getOrElse(index) {
+        defaultSelectionOrder.firstOrNull() ?: "plot_id"
+    }
+    val storedLabel = settings.getString(infoBarAttributeKey(index), fallbackLabel)
+    val storedTraitId = settings.getString(infoBarTraitKey(index), DefaultInfoBarTraitId)
+
+    if (storedTraitId != DefaultInfoBarTraitId) {
+        val trait = allTraits.firstOrNull { it.id?.toString() == storedTraitId }
+        if (trait?.id != null) {
+            return InfoBarSelection(label = trait.name, traitId = trait.id)
+        }
+    }
+
+    val normalizedLabel = if (storedLabel in availableAttributes || storedLabel == fallbackLabel) {
+        storedLabel
+    } else {
+        fallbackLabel
+    }
+
+    return InfoBarSelection(label = normalizedLabel)
+}
+
+private fun persistInfoBarSelection(
+    settings: Settings,
+    index: Int,
+    selection: InfoBarSelection,
+) {
+    settings.putString(infoBarAttributeKey(index), selection.label)
+    settings.putString(
+        infoBarTraitKey(index),
+        selection.traitId?.toString() ?: DefaultInfoBarTraitId
+    )
+}
+
+private fun resolveInfoBarValue(
+    controller: CollectScreenController,
+    selection: InfoBarSelection,
+    fieldNameLabel: String,
+    fieldNameValue: String,
+    noDataLabel: String,
+    attributeValues: Map<String, String>,
+    allTraits: List<TraitObject>,
+    showCategoryLabels: Boolean,
+): String {
+    selection.traitId?.let { traitId ->
+        val rawValue = controller.traitValues[traitId]?.lastOrNull()
+        if (rawValue.isNullOrBlank()) {
+            return noDataLabel
+        }
+
+        val trait = allTraits.firstOrNull { it.id == traitId }
+        return when (trait?.format?.lowercase()) {
+            "categorical", "multicat" -> {
+                CategoryJsonUtil.flattenMultiCategoryValue(
+                    CategoryJsonUtil.decode(rawValue),
+                    showLabel = showCategoryLabels
+                ).ifBlank { noDataLabel }
+            }
+
+            else -> rawValue
+        }
+    }
+
+    if (selection.label == fieldNameLabel) {
+        return fieldNameValue
+    }
+
+    return attributeValues[selection.label]
+        ?.takeIf { it.isNotBlank() }
+        ?: resolveRangeFallback(controller, selection.label).ifBlank { noDataLabel }
+}
+
+private fun resolveRangeFallback(
+    controller: CollectScreenController,
+    label: String,
+): String {
+    return when (label) {
+        controller.uniqueId -> controller.cRange.uniqueId
+        controller.primaryId -> controller.cRange.primaryId
+        controller.secondaryId -> controller.cRange.secondaryId
+        else -> ""
+    }
+}
+
+private fun infoBarAttributeKey(index: Int): String = "DROP$index"
+
+private fun infoBarTraitKey(index: Int): String = "DROP.TRAIT$index"
+
+private fun infoBarWordWrapKey(index: Int): String = "INFOBAR_WORD_WRAP_$index"
+
+private fun infoBarIcon(index: Int, isWordWrapped: Boolean): DrawableResource {
+    val enabledIcons = listOf(
+        Res.drawable.ic_infobar_rhombus,
+        Res.drawable.ic_infobar_circle,
+        Res.drawable.ic_infobar_triangle,
+        Res.drawable.ic_infobar_square_rounded,
+        Res.drawable.ic_infobar_pentagon,
+        Res.drawable.ic_infobar_hexagon
+    )
+    val disabledIcons = listOf(
+        Res.drawable.ic_infobar_rhombus_outline,
+        Res.drawable.ic_infobar_circle_outline,
+        Res.drawable.ic_infobar_triangle_outline,
+        Res.drawable.ic_infobar_square_rounded_outline,
+        Res.drawable.ic_infobar_pentagon_outline,
+        Res.drawable.ic_infobar_hexagon_outline
+    )
+    val icons = if (isWordWrapped) enabledIcons else disabledIcons
+    return icons[index % icons.size]
 }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/RangeBox.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/RangeBox.kt
@@ -67,8 +67,8 @@ fun RangeBox(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             IconButton(
-                onClick = { controller.updateCurrentUnitIndex(controller.currentUnitIndex - 1) },
-                enabled = !controller.collectInteractionLocked && controller.currentUnitIndex > 0,
+                onClick = { controller.goToPreviousUnit() },
+                enabled = !controller.collectInteractionLocked && controller.units.isNotEmpty(),
                 modifier = Modifier.size(56.dp)
             ) {
                 Icon(
@@ -97,8 +97,8 @@ fun RangeBox(
                 )
             }
             IconButton(
-                onClick = { controller.updateCurrentUnitIndex(controller.currentUnitIndex + 1) },
-                enabled = !controller.collectInteractionLocked && controller.currentUnitIndex < controller.units.size - 1,
+                onClick = { controller.goToNextUnit() },
+                enabled = !controller.collectInteractionLocked && controller.units.isNotEmpty(),
                 modifier = Modifier.size(56.dp)
             ) {
                 Icon(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/RangeBox.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/RangeBox.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -22,6 +23,8 @@ import androidx.compose.ui.unit.dp
 import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.chevron_left
 import com.fieldbook.shared.generated.resources.chevron_right
+import com.fieldbook.shared.preferences.PreferenceKeys
+import com.russhwolf.settings.Settings
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
@@ -47,6 +50,9 @@ fun RangeBox(
     controller: CollectScreenController,
     modifier: Modifier = Modifier,
 ) {
+    val settings = remember { Settings() }
+    val showRangeProgressBar = settings.getBoolean(PreferenceKeys.RANGE_PROGRESS_BAR, true)
+
     LaunchedEffect(controller.currentUnitIndex) {
         val id = controller.rangeID.getOrNull(controller.currentUnitIndex)
         if (id != null) {
@@ -55,12 +61,16 @@ fun RangeBox(
     }
 
     Column(modifier = modifier.fillMaxWidth()) {
-        PlotsProgressBar(
-            currentIndex = controller.currentUnitIndex,
-            total = controller.units.size,
-            visible = true // Optionally, make this conditional on a preference
-        )
-        Spacer(Modifier.size(16.dp))
+        if (showRangeProgressBar) {
+            PlotsProgressBar(
+                currentIndex = controller.currentUnitIndex,
+                total = controller.units.size,
+                visible = true
+            )
+            Spacer(Modifier.size(16.dp))
+        } else {
+            Spacer(Modifier.size(8.dp))
+        }
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/StatusBar.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/StatusBar.kt
@@ -1,23 +1,27 @@
 package com.fieldbook.shared.screens.collect
 
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.Alignment
-import org.jetbrains.compose.resources.painterResource
-import com.fieldbook.shared.generated.resources.Res
 import androidx.compose.material3.Icon
-import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.circle_filled
 import com.fieldbook.shared.generated.resources.circle_outline
-import com.fieldbook.shared.generated.resources.square_rounded_filled
-import com.fieldbook.shared.generated.resources.square_rounded_outline
-import androidx.compose.material3.MaterialTheme
+import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun StatusBar(
@@ -35,23 +39,30 @@ fun StatusBar(
         }
         return
     }
-    Row(
+
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(viewModel.currentTraitIndex, viewModel.traits.size) {
+        if (viewModel.traits.isNotEmpty()) {
+            listState.animateScrollToItem(viewModel.currentTraitIndex)
+        }
+    }
+
+    LazyRow(
+        state = listState,
         modifier = modifier
-            .horizontalScroll(rememberScrollState())
             .height(32.dp)
             .fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
     ) {
-        viewModel.traits.forEachIndexed { index, trait ->
+        itemsIndexed(
+            items = viewModel.traits,
+            key = { _, trait -> trait.id ?: trait.name }
+        ) { index, trait ->
             val hasObservation = viewModel.traitValues[trait.id] != null
             val isCurrent = index == viewModel.currentTraitIndex
-            val iconRes = if (isCurrent) {
-                if (hasObservation) Res.drawable.square_rounded_filled else Res.drawable.square_rounded_outline
-            } else {
-                if (hasObservation) Res.drawable.circle_filled else Res.drawable.circle_outline
-            }
+            val iconRes = if (hasObservation) Res.drawable.circle_filled else Res.drawable.circle_outline
             val iconColor = if (isCurrent) {
-                MaterialTheme.colorScheme.primaryContainer
+                MaterialTheme.colorScheme.primary
             } else {
                 MaterialTheme.colorScheme.secondary
             }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/TraitBox.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/TraitBox.kt
@@ -35,8 +35,8 @@ fun TraitBox(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             IconButton(
-                onClick = { viewModel.updateCurrentTraitIndex(viewModel.currentTraitIndex - 1) },
-                enabled = !viewModel.collectInteractionLocked && viewModel.currentTraitIndex > 0,
+                onClick = { viewModel.goToPreviousTrait() },
+                enabled = !viewModel.collectInteractionLocked && viewModel.traits.isNotEmpty(),
                 modifier = Modifier.size(56.dp)
             ) {
                 Icon(
@@ -53,8 +53,8 @@ fun TraitBox(
                 modifier = Modifier.align(Alignment.CenterVertically)
             )
             IconButton(
-                onClick = { viewModel.updateCurrentTraitIndex(viewModel.currentTraitIndex + 1) },
-                enabled = !viewModel.collectInteractionLocked && viewModel.currentTraitIndex < viewModel.traits.size - 1,
+                onClick = { viewModel.goToNextTrait() },
+                enabled = !viewModel.collectInteractionLocked && viewModel.traits.isNotEmpty(),
                 modifier = Modifier.size(56.dp)
             ) {
                 Icon(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/TraitBox.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/TraitBox.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -21,6 +22,8 @@ import androidx.compose.ui.unit.dp
 import com.fieldbook.shared.generated.resources.Res
 import com.fieldbook.shared.generated.resources.chevron_left
 import com.fieldbook.shared.generated.resources.chevron_right
+import com.fieldbook.shared.preferences.PreferenceKeys
+import com.russhwolf.settings.Settings
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
@@ -28,6 +31,9 @@ fun TraitBox(
     viewModel: CollectScreenController,
     modifier: Modifier = Modifier
 ) {
+    val settings = remember { Settings() }
+    val showTraitProgressBar = settings.getBoolean(PreferenceKeys.TRAITS_PROGRESS_BAR, true)
+
     Column(modifier = modifier.fillMaxWidth().padding(16.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -80,12 +86,14 @@ fun TraitBox(
                 textAlign = TextAlign.Center
             )
         }
-        Spacer(Modifier.height(16.dp))
-        Row(modifier = Modifier.fillMaxWidth()) {
-            StatusBar(
-                viewModel = viewModel,
-                modifier = Modifier.fillMaxWidth()
-            )
+        if (showTraitProgressBar) {
+            Spacer(Modifier.height(16.dp))
+            Row(modifier = Modifier.fillMaxWidth()) {
+                StatusBar(
+                    viewModel = viewModel,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTrait.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/AudioTrait.kt
@@ -244,13 +244,13 @@ private fun AudioInfoCard(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold
-            )
-
             if (metadata != null) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold
+                )
+
                 Text(
                     text = "${stringResource(Res.string.trait_audio_timestamp)}${metadata.timestamp}",
                     style = MaterialTheme.typography.bodyLarge,

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/DiseaseRatingTrait.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/DiseaseRatingTrait.kt
@@ -70,6 +70,10 @@ private suspend fun loadRustCodes(): List<String> = withContext(Dispatchers.Defa
 }
 
 private fun appendDiseaseRatingValue(currentValue: String, pressedValue: String): String? {
+    if (currentValue == "NA") {
+        return pressedValue
+    }
+
     if (currentValue.isNotEmpty() &&
         pressedValue != "/" &&
         !currentValue.endsWith("/")
@@ -100,6 +104,14 @@ fun DiseaseRatingTrait(
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
+        if (value == "NA") {
+            Text(
+                text = "NA",
+                color = Color.Black,
+                style = rustLetterTextStyle
+            )
+        }
+
         rustCodes.chunked(6).forEach { rowCodes ->
             Box(modifier = Modifier.fillMaxWidth()) {
                 Row(

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/PhotoTrait.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/PhotoTrait.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -127,10 +128,13 @@ fun PhotoTrait(
         return storedValues
             .flatMap { it.split(PHOTO_VALUE_SEPARATOR) }
             .map(::normalizeStoredPhotoRef)
-            .filter { it.isNotBlank() }
+            .filter { it.isNotBlank() && it != "NA" }
     }
 
     val valuesKey = values.joinToString(PHOTO_VALUE_SEPARATOR)
+    val hasNaPlaceholder = remember(valuesKey) {
+        values.any { it.trim() == "NA" }
+    }
     val photoUris = remember(valuesKey) {
         val initial = decodeStoredPhotoRefs(values)
         mutableStateOf(initial)
@@ -366,6 +370,30 @@ fun PhotoTrait(
         ) {
             val itemWidth = 230.dp
             val itemShape = RoundedCornerShape(8.dp)
+
+            if (hasNaPlaceholder && photoUris.value.isEmpty()) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .width(itemWidth)
+                            .clip(itemShape)
+                            .border(
+                                width = 1.dp,
+                                color = MaterialTheme.colorScheme.outline,
+                                shape = itemShape
+                            )
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "NA",
+                            style = MaterialTheme.typography.headlineMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
 
             // Images
             itemsIndexed(photoUris.value) { index, photoUri ->

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/TextTrait.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/TextTrait.kt
@@ -34,6 +34,7 @@ fun TextTrait(
     isEdited: Boolean = false,
     editedColor: Color = Color.Unspecified,
     closeKeyboardOnOpen: Boolean = false,
+    enabled: Boolean = true,
 ) {
     var local by remember {
         mutableStateOf(
@@ -56,7 +57,7 @@ fun TextTrait(
     }
 
     LaunchedEffect(closeKeyboardOnOpen) {
-        if (closeKeyboardOnOpen) {
+        if (!enabled || closeKeyboardOnOpen) {
             keyboardController?.hide()
         } else {
             focusRequester.requestFocus()
@@ -70,6 +71,7 @@ fun TextTrait(
             local = v.copy(selection = TextRange(v.text.length))
             onValueChange(v.text)
         },
+        enabled = enabled,
         modifier = modifier
             .fillMaxWidth()
             .focusRequester(focusRequester),

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/TextTrait.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/collect/traits/TextTrait.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -15,15 +15,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.graphics.Color
 
 @Composable
 fun TextTrait(
@@ -77,14 +77,10 @@ fun TextTrait(
             .focusRequester(focusRequester),
         singleLine = true,
         textStyle = MaterialTheme.typography.titleLarge.copy(
-            fontWeight = FontWeight.Bold,
+            fontWeight = if (isEdited) FontWeight.Normal else FontWeight.Bold,
             textAlign = TextAlign.Center,
-            fontStyle = if (isEdited) FontStyle.Italic else FontStyle.Normal,
-            color = if (isEdited) {
-                if (editedColor == Color.Unspecified) MaterialTheme.colorScheme.onSurface else editedColor
-            } else {
-                MaterialTheme.colorScheme.onSurface
-            },
+            fontStyle = if (isEdited) FontStyle.Normal else FontStyle.Italic,
+            color = if (editedColor == Color.Unspecified) MaterialTheme.colorScheme.onSurface else editedColor,
         ),
         decorationBox = { innerTextField ->
             if (local.text.isBlank() && !defaultValue.isNullOrBlank()) {

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/components/NumberStepperDialog.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/components/NumberStepperDialog.kt
@@ -1,0 +1,156 @@
+package com.fieldbook.shared.screens.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.save
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun NumberStepperDialog(
+    title: String,
+    summary: String,
+    initialValue: Int,
+    onDismiss: () -> Unit,
+    onSave: (Int) -> Unit,
+    range: IntRange = 1..20,
+) {
+    var count by remember(initialValue, range) {
+        mutableStateOf(initialValue.coerceIn(range.first, range.last))
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth(0.85f),
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(18.dp),
+            tonalElevation = 6.dp,
+            shadowElevation = 8.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 20.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = null
+                        )
+                    }
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                Text(
+                    text = summary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp, bottom = 16.dp)
+                )
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(18.dp),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                    tonalElevation = 1.dp
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 10.dp, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        TextButton(
+                            onClick = { count = (count - 1).coerceAtLeast(range.first) },
+                            enabled = count > range.first
+                        ) {
+                            Text(
+                                text = "-",
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+
+                        Surface(
+                            modifier = Modifier.weight(1f),
+                            shape = androidx.compose.foundation.shape.RoundedCornerShape(14.dp),
+                            color = MaterialTheme.colorScheme.surfaceVariant
+                        ) {
+                            Text(
+                                text = count.toString(),
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Bold,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 12.dp)
+                            )
+                        }
+
+                        TextButton(
+                            onClick = { count = (count + 1).coerceAtMost(range.last) },
+                            enabled = count < range.last
+                        ) {
+                            Text(
+                                text = "+",
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text("Cancel")
+                    }
+                    TextButton(onClick = { onSave(count) }) {
+                        Text(stringResource(Res.string.save))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/AppearancePreferencesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/AppearancePreferencesScreen.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -16,27 +18,54 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.fieldbook.shared.KmpHostScreenType
 import com.fieldbook.shared.generated.resources.Res
+import com.fieldbook.shared.generated.resources.ic_adv_infobar_count
+import com.fieldbook.shared.generated.resources.ic_hide_infobar_prefix
 import com.fieldbook.shared.generated.resources.ic_nav_drawer_translate
 import com.fieldbook.shared.generated.resources.ic_pref_appearance_theme
+import com.fieldbook.shared.generated.resources.ic_pref_appearance_toolbar
+import com.fieldbook.shared.generated.resources.ic_range_progress
+import com.fieldbook.shared.generated.resources.ic_traits_progress
+import com.fieldbook.shared.generated.resources.preferences_appearance_collect_screen_title
 import com.fieldbook.shared.generated.resources.preference_language_default
 import com.fieldbook.shared.generated.resources.preferences_appearance_application_title
+import com.fieldbook.shared.generated.resources.preferences_appearance_infobar_hide_prefix
+import com.fieldbook.shared.generated.resources.preferences_appearance_infobar_hide_prefix_description
+import com.fieldbook.shared.generated.resources.preferences_appearance_infobar_number
+import com.fieldbook.shared.generated.resources.preferences_appearance_infobar_number_description
 import com.fieldbook.shared.generated.resources.preferences_appearance_language
 import com.fieldbook.shared.generated.resources.preferences_appearance_language_description
+import com.fieldbook.shared.generated.resources.preferences_appearance_range_progress_bar
+import com.fieldbook.shared.generated.resources.preferences_appearance_range_progress_bar_description
+import com.fieldbook.shared.generated.resources.preferences_appearance_toolbar_customize
+import com.fieldbook.shared.generated.resources.preferences_appearance_toolbar_customize_description
+import com.fieldbook.shared.generated.resources.preferences_appearance_toolbar_customize_lock
+import com.fieldbook.shared.generated.resources.preferences_appearance_toolbar_customize_resources
+import com.fieldbook.shared.generated.resources.preferences_appearance_toolbar_customize_search
+import com.fieldbook.shared.generated.resources.preferences_appearance_toolbar_customize_summary
 import com.fieldbook.shared.generated.resources.preferences_appearance_theme_summary
 import com.fieldbook.shared.generated.resources.preferences_appearance_theme_title
+import com.fieldbook.shared.generated.resources.preferences_appearance_traits_progress_bar
+import com.fieldbook.shared.generated.resources.preferences_appearance_traits_progress_bar_description
 import com.fieldbook.shared.generated.resources.preferences_appearance_title
 import com.fieldbook.shared.preferences.PreferenceKeys
+import com.fieldbook.shared.screens.components.NumberStepperDialog
 import com.russhwolf.settings.Settings
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource
@@ -57,6 +86,15 @@ private data class ToolbarOption(
     val title: StringResource
 )
 
+private data class AppearanceTogglePreferenceRow(
+    val icon: DrawableResource,
+    val title: StringResource,
+    val summary: StringResource,
+    val checked: Boolean,
+    val enabled: Boolean = true,
+    val onCheckedChange: (Boolean) -> Unit
+)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppearancePreferencesScreen(
@@ -65,10 +103,102 @@ fun AppearancePreferencesScreen(
 ) {
     val settings = remember { Settings() }
     val languageDefaultSummary = stringResource(Res.string.preference_language_default)
+    val infoBarNumberTitle = stringResource(Res.string.preferences_appearance_infobar_number)
+    val infoBarNumberSummary = stringResource(Res.string.preferences_appearance_infobar_number_description)
+    val searchToolbarLabel = stringResource(Res.string.preferences_appearance_toolbar_customize_search)
+    val resourcesToolbarLabel = stringResource(Res.string.preferences_appearance_toolbar_customize_resources)
+    val summaryToolbarLabel = stringResource(Res.string.preferences_appearance_toolbar_customize_summary)
+    val lockToolbarLabel = stringResource(Res.string.preferences_appearance_toolbar_customize_lock)
+    val toolbarOptions = remember {
+        listOf(
+            ToolbarOption("search", Res.string.preferences_appearance_toolbar_customize_search),
+            ToolbarOption("resources", Res.string.preferences_appearance_toolbar_customize_resources),
+            ToolbarOption("summary", Res.string.preferences_appearance_toolbar_customize_summary),
+            ToolbarOption("lockData", Res.string.preferences_appearance_toolbar_customize_lock)
+        )
+    }
 
     val languageSummary = settings.getString(
         PreferenceKeys.LANGUAGE_LOCALE_SUMMARY,
         languageDefaultSummary
+    )
+    var dialogState by remember { mutableStateOf<PreferenceDialogState?>(null) }
+    var showToolbarActionsDialog by remember { mutableStateOf(false) }
+    var showInfoBarCountDialog by remember { mutableStateOf(false) }
+    var toolbarCustomization by remember {
+        mutableStateOf(loadToolbarCustomization(settings, toolbarOptions.map { it.value }.toSet()))
+    }
+    var infoBarCount by remember {
+        mutableStateOf(settings.getInt(PreferenceKeys.INFOBAR_NUMBER, 3).coerceIn(1, 20))
+    }
+    var hideInfoBarPrefix by remember {
+        mutableStateOf(settings.getBoolean(PreferenceKeys.HIDE_INFOBAR_PREFIX, false))
+    }
+    var rangeProgressBarEnabled by remember {
+        mutableStateOf(settings.getBoolean(PreferenceKeys.RANGE_PROGRESS_BAR, true))
+    }
+    var traitsProgressBarEnabled by remember {
+        mutableStateOf(settings.getBoolean(PreferenceKeys.TRAITS_PROGRESS_BAR, true))
+    }
+
+    fun updateToolbarCustomization(option: String, enabled: Boolean) {
+        toolbarCustomization = toolbarCustomization.toMutableSet().apply {
+            if (enabled) add(option) else remove(option)
+        }
+        settings.putString(
+            PreferenceKeys.TOOLBAR_CUSTOMIZE,
+            toolbarOptions
+                .mapNotNull { toolbarOption ->
+                    toolbarOption.value.takeIf { it in toolbarCustomization }
+                }
+                .joinToString(",")
+        )
+    }
+
+    val selectedToolbarActionsSummary = toolbarOptions
+        .mapNotNull { option -> option.takeIf { option.value in toolbarCustomization } }
+        .joinToString(", ") { option ->
+            when (option.value) {
+                "search" -> searchToolbarLabel
+                "resources" -> resourcesToolbarLabel
+                "summary" -> summaryToolbarLabel
+                "lockData" -> lockToolbarLabel
+                else -> option.value
+            }
+        }
+        .ifBlank { "-" }
+
+    val collectTogglePreferences = listOf(
+        AppearanceTogglePreferenceRow(
+            icon = Res.drawable.ic_hide_infobar_prefix,
+            title = Res.string.preferences_appearance_infobar_hide_prefix,
+            summary = Res.string.preferences_appearance_infobar_hide_prefix_description,
+            checked = hideInfoBarPrefix,
+            onCheckedChange = { enabled ->
+                hideInfoBarPrefix = enabled
+                settings.putBoolean(PreferenceKeys.HIDE_INFOBAR_PREFIX, enabled)
+            }
+        ),
+        AppearanceTogglePreferenceRow(
+            icon = Res.drawable.ic_range_progress,
+            title = Res.string.preferences_appearance_range_progress_bar,
+            summary = Res.string.preferences_appearance_range_progress_bar_description,
+            checked = rangeProgressBarEnabled,
+            onCheckedChange = { enabled ->
+                rangeProgressBarEnabled = enabled
+                settings.putBoolean(PreferenceKeys.RANGE_PROGRESS_BAR, enabled)
+            }
+        ),
+        AppearanceTogglePreferenceRow(
+            icon = Res.drawable.ic_traits_progress,
+            title = Res.string.preferences_appearance_traits_progress_bar,
+            summary = Res.string.preferences_appearance_traits_progress_bar_description,
+            checked = traitsProgressBarEnabled,
+            onCheckedChange = { enabled ->
+                traitsProgressBarEnabled = enabled
+                settings.putBoolean(PreferenceKeys.TRAITS_PROGRESS_BAR, enabled)
+            }
+        )
     )
 
     Surface(modifier = Modifier.fillMaxSize()) {
@@ -121,11 +251,109 @@ fun AppearancePreferencesScreen(
                     )
                     HorizontalDivider()
                 }
-
+                item {
+                    PreferenceSectionTitle(Res.string.preferences_appearance_collect_screen_title)
+                }
+                item {
+                    AppearancePreferenceListRow(
+                        item = AppearancePreferenceRow(
+                            icon = Res.drawable.ic_pref_appearance_toolbar,
+                            title = Res.string.preferences_appearance_toolbar_customize,
+                            summary = Res.string.preferences_appearance_toolbar_customize_description,
+                            value = selectedToolbarActionsSummary,
+                            onClick = { showToolbarActionsDialog = true }
+                        )
+                    )
+                    HorizontalDivider()
+                }
+                item {
+                    AppearancePreferenceListRow(
+                        item = AppearancePreferenceRow(
+                            icon = Res.drawable.ic_adv_infobar_count,
+                            title = Res.string.preferences_appearance_infobar_number,
+                            summary = Res.string.preferences_appearance_infobar_number_description,
+                            value = infoBarCount.toString(),
+                            onClick = { showInfoBarCountDialog = true }
+                        )
+                    )
+                    HorizontalDivider()
+                }
+                collectTogglePreferences.forEach { preference ->
+                    item {
+                        AppearancePreferenceToggleRow(item = preference)
+                        HorizontalDivider()
+                    }
+                }
             }
         }
     }
 
+    if (showToolbarActionsDialog) {
+        ToolbarActionsDialog(
+            options = toolbarOptions.map { option ->
+                AppearanceTogglePreferenceRow(
+                    icon = Res.drawable.ic_pref_appearance_toolbar,
+                    title = option.title,
+                    summary = Res.string.preferences_appearance_toolbar_customize_description,
+                    checked = option.value in toolbarCustomization,
+                    enabled = option.value == "summary" || option.value == "lockData",
+                    onCheckedChange = { enabled ->
+                        if (option.value == "summary" || option.value == "lockData") {
+                            updateToolbarCustomization(option.value, enabled)
+                        }
+                    }
+                )
+            },
+            onDismiss = { showToolbarActionsDialog = false }
+        )
+    }
+
+    if (showInfoBarCountDialog) {
+        NumberStepperDialog(
+            title = infoBarNumberTitle,
+            summary = infoBarNumberSummary,
+            initialValue = infoBarCount,
+            onDismiss = { showInfoBarCountDialog = false },
+            onSave = { updatedCount ->
+                infoBarCount = updatedCount
+                settings.putInt(PreferenceKeys.INFOBAR_NUMBER, updatedCount)
+                showInfoBarCountDialog = false
+            }
+        )
+    }
+
+    dialogState?.let { state ->
+        when (state.type) {
+            PreferenceDialogType.TEXT -> PreferenceTextDialog(
+                state = state,
+                onDismiss = { dialogState = null }
+            )
+            PreferenceDialogType.OPTIONS -> PreferenceOptionsDialog(
+                state = state,
+                onDismiss = { dialogState = null }
+            )
+            PreferenceDialogType.INFO -> PreferenceInfoDialog(
+                state = state,
+                onDismiss = { dialogState = null }
+            )
+        }
+    }
+}
+
+private fun loadToolbarCustomization(
+    settings: Settings,
+    defaultOptions: Set<String>
+): Set<String> {
+    val serialized = settings.getStringOrNull(PreferenceKeys.TOOLBAR_CUSTOMIZE)
+    if (serialized == null) {
+        return defaultOptions
+    }
+
+    return serialized
+        .split(',', '\n')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .toSet()
 }
 
 @Composable
@@ -176,3 +404,103 @@ private fun AppearancePreferenceListRow(item: AppearancePreferenceRow) {
     }
 }
 
+@Composable
+private fun AppearancePreferenceToggleRow(item: AppearanceTogglePreferenceRow) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = item.enabled) { item.onCheckedChange(!item.checked) }
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .graphicsLayer { alpha = if (item.enabled) 1f else 0.45f },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(item.icon),
+            contentDescription = stringResource(item.title),
+            modifier = Modifier
+                .padding(end = 16.dp)
+                .size(24.dp)
+        )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 16.dp)
+        ) {
+            Text(
+                text = stringResource(item.title),
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Text(
+                text = stringResource(item.summary),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Switch(
+            checked = item.checked,
+            enabled = item.enabled,
+            onCheckedChange = item.onCheckedChange
+        )
+    }
+}
+
+@Composable
+private fun ToolbarActionsDialog(
+    options: List<AppearanceTogglePreferenceRow>,
+    onDismiss: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp),
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(18.dp),
+            tonalElevation = 6.dp,
+            shadowElevation = 8.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 20.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = null
+                        )
+                    }
+                    Text(
+                        text = stringResource(Res.string.preferences_appearance_toolbar_customize),
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                Text(
+                    text = stringResource(Res.string.preferences_appearance_toolbar_customize_description),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp, bottom = 12.dp)
+                )
+
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 340.dp)
+                ) {
+                    items(options) { option ->
+                        AppearancePreferenceToggleRow(item = option)
+                        HorizontalDivider()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/AppearancePreferencesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/fieldbook/shared/screens/preferences/AppearancePreferencesScreen.kt
@@ -65,6 +65,8 @@ import com.fieldbook.shared.generated.resources.preferences_appearance_traits_pr
 import com.fieldbook.shared.generated.resources.preferences_appearance_traits_progress_bar_description
 import com.fieldbook.shared.generated.resources.preferences_appearance_title
 import com.fieldbook.shared.preferences.PreferenceKeys
+import com.fieldbook.shared.preferences.loadToolbarCustomizationPreference
+import com.fieldbook.shared.preferences.persistToolbarCustomizationPreference
 import com.fieldbook.shared.screens.components.NumberStepperDialog
 import com.russhwolf.settings.Settings
 import org.jetbrains.compose.resources.DrawableResource
@@ -145,13 +147,14 @@ fun AppearancePreferencesScreen(
         toolbarCustomization = toolbarCustomization.toMutableSet().apply {
             if (enabled) add(option) else remove(option)
         }
-        settings.putString(
-            PreferenceKeys.TOOLBAR_CUSTOMIZE,
-            toolbarOptions
+        persistToolbarCustomizationPreference(
+            settings = settings,
+            key = PreferenceKeys.TOOLBAR_CUSTOMIZE,
+            values = toolbarOptions
                 .mapNotNull { toolbarOption ->
                     toolbarOption.value.takeIf { it in toolbarCustomization }
                 }
-                .joinToString(",")
+                .toSet()
         )
     }
 
@@ -344,16 +347,11 @@ private fun loadToolbarCustomization(
     settings: Settings,
     defaultOptions: Set<String>
 ): Set<String> {
-    val serialized = settings.getStringOrNull(PreferenceKeys.TOOLBAR_CUSTOMIZE)
-    if (serialized == null) {
-        return defaultOptions
-    }
-
-    return serialized
-        .split(',', '\n')
-        .map { it.trim() }
-        .filter { it.isNotEmpty() }
-        .toSet()
+    return loadToolbarCustomizationPreference(
+        settings = settings,
+        key = PreferenceKeys.TOOLBAR_CUSTOMIZE,
+        defaultOptions = defaultOptions
+    )
 }
 
 @Composable

--- a/shared/src/iosMain/kotlin/com/fieldbook/shared/preferences/StringSetPreference.ios.kt
+++ b/shared/src/iosMain/kotlin/com/fieldbook/shared/preferences/StringSetPreference.ios.kt
@@ -1,0 +1,22 @@
+package com.fieldbook.shared.preferences
+
+import com.russhwolf.settings.Settings
+
+actual fun loadStringSetPreference(
+    settings: Settings,
+    key: String,
+    legacySeparators: CharArray,
+): Set<String>? {
+    return decodeStoredStringSetPreference(
+        serialized = settings.getStringOrNull(key),
+        legacySeparators = legacySeparators
+    )
+}
+
+actual fun persistStringSetPreference(
+    settings: Settings,
+    key: String,
+    values: Set<String>,
+) {
+    settings.putString(key, encodeStoredStringSetPreference(values))
+}

--- a/shared/src/iosMain/kotlin/com/fieldbook/shared/preferences/ToolbarCustomizationPreference.ios.kt
+++ b/shared/src/iosMain/kotlin/com/fieldbook/shared/preferences/ToolbarCustomizationPreference.ios.kt
@@ -1,0 +1,27 @@
+package com.fieldbook.shared.preferences
+
+import com.russhwolf.settings.Settings
+
+actual fun loadToolbarCustomizationPreference(
+    settings: Settings,
+    key: String,
+    defaultOptions: Set<String>,
+): Set<String> {
+    return loadStringSetPreference(
+        settings = settings,
+        key = key,
+        legacySeparators = charArrayOf(',', '\n')
+    ) ?: defaultOptions
+}
+
+actual fun persistToolbarCustomizationPreference(
+    settings: Settings,
+    key: String,
+    values: Set<String>,
+) {
+    persistStringSetPreference(
+        settings = settings,
+        key = key,
+        values = values
+    )
+}


### PR DESCRIPTION
### Description

This PR expands the KMP Collect experience to better match the native Android implementation and adds the supporting Appearance preferences needed to control that behavior.

Included work in this branch:
- Added circular navigation for both traits and observation units.
- Added data lock support to Collect and blocked text editing while data is locked.
- Added the Collect bottom toolbar with delete, NA, and scanner-driven workflows.
- Implemented the Collect Summary flow, including summary label persistence.
- Added configurable InfoBar support in Collect, including attribute/trait selection and customization.
- Added shared Appearance preferences for Collect, including toolbar actions, InfoBar count, hide infobar prefix, and progress bar toggles.
- Added preference-controlled visibility for RangeBox and TraitBox progress indicators.
- Added observation unit attribute lookup support needed by InfoBar and Summary.
- Fixed Notes trait layout so note text stays above the green divider.

### Change Type

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [x] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

```release-note
Expanded the KMP Collect screen with configurable InfoBars, Summary support, bottom toolbar actions, data lock handling, circular navigation, scanner integration, and new Appearance options for Collect customization.