### PR TITLE
IBP-7142 fix material datepicker / sdk 36 / compose 1.10.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin-plugin-compose = "2.3.10" # same as main app build.gradle
-compose = "1.7.3" # compatible with compileSdk = 34
+compose = "1.10.3" # compatible with compileSdk = 36
 multiplatform-settings = "1.3.0"
 lifecycle-viewmodel-compose = "2.8.4" # compatible with compose
 navigation-compose = "2.8.0-alpha11" # aligned with Compose Multiplatform 1.7.3

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -338,8 +338,10 @@ kotlin {
     // See: https://kotlinlang.org/docs/multiplatform-discover-project.html#targets
     androidLibrary {
         namespace = "com.fieldbook.shared"
-        compileSdk = 34
+        compileSdk = 36 // match app/build.gradle compileSdkVersion
         minSdk = 21
+
+        experimentalProperties["android.experimental.kmp.enableAndroidResources"] = true
 
         withHostTestBuilder {
         }
@@ -387,6 +389,7 @@ kotlin {
                 implementation(compose.runtime)
                 implementation(compose.foundation)
                 implementation(compose.material3)
+                implementation(compose.materialIconsExtended)
                 implementation(compose.ui)
                 implementation(compose.components.resources)
                 implementation("io.github.kashif-mehmood-km:camerak:0.0.6")


### PR DESCRIPTION
- use sdk 36 (same as native app on 6.3.6)
- bump compose to 1.10.3 (compatible with sdk 36)
- fixed material3 ABI mismatch for DatePicker

<img width="411" height="633" alt="collect_datepicker" src="https://github.com/user-attachments/assets/cd49f622-bedd-448c-9d83-ddf2f9fc8cdf" />

After #45 

<img width="425" height="553" alt="heatmap_datepicker" src="https://github.com/user-attachments/assets/fe43a4e7-4861-4f25-bcab-4e37eae61e97" />
